### PR TITLE
fix: preserve `maintainers` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ By default, these properties are preserved in `package.json`:
 - `description`
 - `keywords`
 - `author`
+- `maintainers`
 - `contributors`
 - `license`
 - `homepage`

--- a/src/default-keep-properties.ts
+++ b/src/default-keep-properties.ts
@@ -43,6 +43,7 @@ export const defaultKeepProperties = [
 	'description',
 	'keywords',
 	'author',
+	'maintainers',
 	'contributors',
 	'license',
 	'homepage',


### PR DESCRIPTION
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#people-fields-author-contributors

<img width="767" alt="image" src="https://github.com/user-attachments/assets/c19d14f5-5ebd-45e4-88f9-ee9aa2acbcc5" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f3b10044-b0dd-4789-a11f-fb5e8d94d693" />
