### PR TITLE
feat: prune unpublished paths from imports and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Uses an allowlist to preserve only [properties relevant to package consumers](#d
 
 For `scripts`, only install hooks (`preinstall`, `install`, `postinstall`, `dependencies`) are preserved. All other scripts are removed.
 
-For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--no-prune` to disable this behavior.
+For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--prune=false` to disable this behavior.
 
 ## Install
 
@@ -101,7 +101,7 @@ Add `clean-pkg-json` to the [`prepack`](https://docs.npmjs.com/cli/v8/using-npm/
 | `-r, --remove <property name>` | Property names to remove. Accepts multiple flags or a comma-delimited list. |
 | `-v, --verbose` | Verbose logs. |
 | `-d, --dry` | Dry run — prints the result instead of writing to disk. |
-| `--no-prune` | Disable pruning of unpublished paths in `exports` and `imports`. |
+| `--prune=false` | Disable pruning of unpublished paths in `exports` and `imports`. |
 | `-h, --help` | Show help |
 | `--version` | Show version |
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Uses an allowlist to preserve only [properties relevant to package consumers](#d
 
 For `scripts`, only install hooks (`preinstall`, `install`, `postinstall`, `dependencies`) are preserved. All other scripts are removed.
 
-For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--prune=false` to disable this behavior.
+For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--published-only=false` to disable this behavior.
 
 ## Install
 
@@ -101,7 +101,7 @@ Add `clean-pkg-json` to the [`prepack`](https://docs.npmjs.com/cli/v8/using-npm/
 | `-r, --remove <property name>` | Property names to remove. Accepts multiple flags or a comma-delimited list. |
 | `-v, --verbose` | Verbose logs. |
 | `-d, --dry` | Dry run — prints the result instead of writing to disk. |
-| `--prune=false` | Disable pruning of unpublished paths in `exports` and `imports`. |
+| `--published-only=false` | Disable pruning of unpublished paths in `exports` and `imports`. |
 | `-h, --help` | Show help |
 | `--version` | Show version |
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Uses an allowlist to preserve only [properties relevant to package consumers](#d
 
 For `scripts`, only install hooks (`preinstall`, `install`, `postinstall`, `dependencies`) are preserved. All other scripts are removed.
 
+For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--no-prune` to disable this behavior.
+
 ## Install
 
 ```sh
@@ -99,6 +101,7 @@ Add `clean-pkg-json` to the [`prepack`](https://docs.npmjs.com/cli/v8/using-npm/
 | `-r, --remove <property name>` | Property names to remove. Accepts multiple flags or a comma-delimited list. |
 | `-v, --verbose` | Verbose logs. |
 | `-d, --dry` | Dry run — prints the result instead of writing to disk. |
+| `--no-prune` | Disable pruning of unpublished paths in `exports` and `imports`. |
 | `-h, --help` | Show help |
 | `--version` | Show version |
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"lintroll": "^1.30.0",
 		"manten": "^2.0.0",
 		"nano-spawn": "^2.0.0",
+		"npm-packlist": "^10.0.4",
 		"pkgroll": "^2.27.0",
 		"skills-npm": "^1.1.0",
 		"type-fest": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       nano-spawn:
         specifier: ^2.0.0
         version: 2.0.0
+      npm-packlist:
+        specifier: ^10.0.4
+        version: 10.0.4
       pkgroll:
         specifier: ^2.27.0
         version: 2.27.0(typescript@5.9.3)
@@ -1812,6 +1815,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  ignore-walk@8.0.0:
+    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2274,6 +2281,10 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  npm-packlist@10.0.4:
+    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -2393,6 +2404,10 @@ packages:
   pretty-format@30.2.0:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4703,6 +4718,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  ignore-walk@8.0.0:
+    dependencies:
+      minimatch: 10.2.4
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5399,6 +5418,11 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  npm-packlist@10.0.4:
+    dependencies:
+      ignore-walk: 8.0.0
+      proc-log: 6.1.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -5531,6 +5555,8 @@ snapshots:
       '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  proc-log@6.1.0: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/src/@types/npm-packlist.d.ts
+++ b/src/@types/npm-packlist.d.ts
@@ -1,0 +1,13 @@
+declare module 'npm-packlist' {
+	type Tree = {
+		path: string;
+		package: Record<string, unknown>;
+		edgesOut: Map<string, unknown>;
+		workspaces?: Map<string, string>;
+		isProjectRoot?: boolean;
+	};
+
+	function packlist(tree: Tree): Promise<string[]>;
+
+	export default packlist;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ const packageJsonPath = './package.json';
 const argv = cli({
 	name,
 	version,
-	booleanFlagNegation: true,
 	flags: {
 		verbose: {
 			type: Boolean,

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ const log = (...args: any[]) => {
 		const publishedFiles = await getPublishedFiles(process.cwd(), packageJson);
 		for (const field of fieldsToPrune) {
 			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles);
-			if (pruned === null) {
+			if (pruned === undefined) {
 				log(`Removing property "${field}" (all paths unpublished)`);
 				delete packageJson[field];
 			} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ const log = (...args: any[]) => {
 		for (const field of fieldsToPrune) {
 			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles);
 			if (pruned === undefined) {
-				log(`Removing property "${field}" (all paths unpublished)`);
+				log(`Removing property "${field}" (no published files referenced)`);
 				delete packageJson[field];
 			} else {
 				packageJson[field] = pruned;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const argv = cli({
 			alias: 'd',
 			description: 'Dry run',
 		},
-		prune: {
+		publishedOnly: {
 			type: Boolean,
 			description: 'Prune unpublished paths from exports/imports',
 			default: true,
@@ -96,7 +96,7 @@ const log = (...args: any[]) => {
 		delete packageJson[property];
 	}
 
-	const fieldsToPrune = argv.flags.prune
+	const fieldsToPrune = argv.flags.publishedOnly
 		? ['imports', 'exports'].filter(field => packageJson[field])
 		: [];
 	if (fieldsToPrune.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
+import { getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
 
 const { name, version, description } = pkg;
 
@@ -88,6 +89,20 @@ const log = (...args: any[]) => {
 
 		log(`Removing property "${property}"`);
 		delete packageJson[property];
+	}
+
+	const fieldsToprune = ['imports', 'exports'].filter(field => packageJson[field]);
+	if (fieldsToprune.length > 0) {
+		const publishedFiles = await getPublishedFiles(process.cwd(), packageJson);
+		for (const field of fieldsToprune) {
+			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles);
+			if (pruned === null) {
+				log(`Removing property "${field}" (all paths unpublished)`);
+				delete packageJson[field];
+			} else {
+				packageJson[field] = pruned;
+			}
+		}
 	}
 
 	const newPackageJsonString = JSON.stringify(packageJson, null, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,10 +91,10 @@ const log = (...args: any[]) => {
 		delete packageJson[property];
 	}
 
-	const fieldsToprune = ['imports', 'exports'].filter(field => packageJson[field]);
-	if (fieldsToprune.length > 0) {
+	const fieldsToPrune = ['imports', 'exports'].filter(field => packageJson[field]);
+	if (fieldsToPrune.length > 0) {
 		const publishedFiles = await getPublishedFiles(process.cwd(), packageJson);
-		for (const field of fieldsToprune) {
+		for (const field of fieldsToPrune) {
 			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles);
 			if (pruned === null) {
 				log(`Removing property "${field}" (all paths unpublished)`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ const packageJsonPath = './package.json';
 const argv = cli({
 	name,
 	version,
+	booleanFlagNegation: true,
 	flags: {
 		verbose: {
 			type: Boolean,
@@ -31,6 +32,11 @@ const argv = cli({
 			type: Boolean,
 			alias: 'd',
 			description: 'Dry run',
+		},
+		prune: {
+			type: Boolean,
+			description: 'Prune unpublished paths from exports/imports',
+			default: true,
 		},
 	},
 	help: {
@@ -91,7 +97,9 @@ const log = (...args: any[]) => {
 		delete packageJson[property];
 	}
 
-	const fieldsToPrune = ['imports', 'exports'].filter(field => packageJson[field]);
+	const fieldsToPrune = argv.flags.prune
+		? ['imports', 'exports'].filter(field => packageJson[field])
+		: [];
 	if (fieldsToPrune.length > 0) {
 		const publishedFiles = await getPublishedFiles(process.cwd(), packageJson);
 		for (const field of fieldsToPrune) {

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -19,29 +19,72 @@ const isRelativePath = (value: string) => value.startsWith('./');
 
 const normalizePath = (value: string) => value.slice(2);
 
-export const pruneUnpublishedPaths = (
+const hasWildcard = (value: string) => value.includes('*');
+
+const wildcardMatchesAnyFile = (
+	pattern: string,
+	publishedFiles: Set<string>,
+) => {
+	const normalized = normalizePath(pattern);
+	const prefix = normalized.slice(0, normalized.indexOf('*'));
+	const suffix = normalized.slice(normalized.indexOf('*') + 1);
+
+	for (const file of Array.from(publishedFiles)) {
+		if (file.startsWith(prefix) && file.endsWith(suffix)) {
+			return true;
+		}
+	}
+	return false;
+};
+
+// Sentinel to distinguish "prune this" from "value is literally null"
+const PRUNE = Symbol('prune');
+
+const pruneValue = (
 	value: unknown,
 	publishedFiles: Set<string>,
 ): unknown => {
+	if (value === null) {
+		return null;
+	}
+
 	if (typeof value === 'string') {
 		if (!isRelativePath(value)) {
 			return value;
 		}
-		return publishedFiles.has(normalizePath(value)) ? value : null;
+		if (hasWildcard(value)) {
+			return wildcardMatchesAnyFile(value, publishedFiles) ? value : PRUNE;
+		}
+		return publishedFiles.has(normalizePath(value)) ? value : PRUNE;
 	}
 
-	if (typeof value === 'object' && value !== null) {
+	if (Array.isArray(value)) {
+		const filtered = value
+			.map(item => pruneValue(item, publishedFiles))
+			.filter(item => item !== PRUNE);
+		return filtered.length > 0 ? filtered : PRUNE;
+	}
+
+	if (typeof value === 'object') {
 		const record = value as Record<string, unknown>;
 		for (const key of Object.keys(record)) {
-			const pruned = pruneUnpublishedPaths(record[key], publishedFiles);
-			if (pruned === null) {
+			const pruned = pruneValue(record[key], publishedFiles);
+			if (pruned === PRUNE) {
 				delete record[key];
 			} else {
 				record[key] = pruned;
 			}
 		}
-		return Object.keys(record).length > 0 ? record : null;
+		return Object.keys(record).length > 0 ? record : PRUNE;
 	}
 
 	return value;
+};
+
+export const pruneUnpublishedPaths = (
+	value: unknown,
+	publishedFiles: Set<string>,
+): unknown => {
+	const result = pruneValue(value, publishedFiles);
+	return result === PRUNE ? null : result;
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -10,6 +10,7 @@ export const getPublishedFiles = async (
 		path: cwd,
 		package: packageJson,
 		edgesOut,
+		isProjectRoot: true,
 	});
 	return new Set(files);
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,0 +1,47 @@
+// @ts-expect-error -- npm-packlist has no type declarations
+import packlist from 'npm-packlist';
+
+const edgesOut = new Map();
+
+export const getPublishedFiles = async (
+	cwd: string,
+	packageJson: Record<string, unknown>,
+) => {
+	const files: string[] = await packlist({
+		path: cwd,
+		package: packageJson,
+		edgesOut,
+	});
+	return new Set(files);
+};
+
+const isRelativePath = (value: string) => value.startsWith('./');
+
+const normalizePath = (value: string) => value.slice(2);
+
+export const pruneUnpublishedPaths = (
+	value: unknown,
+	publishedFiles: Set<string>,
+): unknown => {
+	if (typeof value === 'string') {
+		if (!isRelativePath(value)) {
+			return value;
+		}
+		return publishedFiles.has(normalizePath(value)) ? value : null;
+	}
+
+	if (typeof value === 'object' && value !== null) {
+		const record = value as Record<string, unknown>;
+		for (const key of Object.keys(record)) {
+			const pruned = pruneUnpublishedPaths(record[key], publishedFiles);
+			if (pruned === null) {
+				delete record[key];
+			} else {
+				record[key] = pruned;
+			}
+		}
+		return Object.keys(record).length > 0 ? record : null;
+	}
+
+	return value;
+};

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error -- npm-packlist has no type declarations
 import packlist from 'npm-packlist';
 
 const edgesOut = new Map();

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -28,13 +28,10 @@ const wildcardMatchesAnyFile = (
 	);
 };
 
-// Sentinel to distinguish "prune this" from "value is literally null"
-const PRUNE = Symbol('prune');
-
-const pruneValue = (
+export const pruneUnpublishedPaths = (
 	value: unknown,
 	publishedFiles: Set<string>,
-): unknown => {
+): unknown | undefined => {
 	if (value === null) {
 		return null;
 	}
@@ -44,38 +41,28 @@ const pruneValue = (
 			return value;
 		}
 		if (value.includes('*')) {
-			return wildcardMatchesAnyFile(value, publishedFiles) ? value : PRUNE;
+			return wildcardMatchesAnyFile(value, publishedFiles) ? value : undefined;
 		}
-		return publishedFiles.has(value.slice(2)) ? value : PRUNE;
+		return publishedFiles.has(value.slice(2)) ? value : undefined;
 	}
 
 	if (Array.isArray(value)) {
-		const filtered = value
-			.map(item => pruneValue(item, publishedFiles))
-			.filter(item => item !== PRUNE);
-		return filtered.length > 0 ? filtered : PRUNE;
+		const kept = value
+			.map(item => pruneUnpublishedPaths(item, publishedFiles))
+			.filter(item => item !== undefined);
+		return kept.length > 0 ? kept : undefined;
 	}
 
 	if (typeof value === 'object') {
-		const record = value as Record<string, unknown>;
-		for (const key of Object.keys(record)) {
-			const pruned = pruneValue(record[key], publishedFiles);
-			if (pruned === PRUNE) {
-				delete record[key];
-			} else {
-				record[key] = pruned;
+		const kept: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(value)) {
+			const pruned = pruneUnpublishedPaths(child, publishedFiles);
+			if (pruned !== undefined) {
+				kept[key] = pruned;
 			}
 		}
-		return Object.keys(record).length > 0 ? record : PRUNE;
+		return Object.keys(kept).length > 0 ? kept : undefined;
 	}
 
 	return value;
-};
-
-export const pruneUnpublishedPaths = (
-	value: unknown,
-	publishedFiles: Set<string>,
-): unknown => {
-	const result = pruneValue(value, publishedFiles);
-	return result === PRUNE ? null : result;
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -15,26 +15,17 @@ export const getPublishedFiles = async (
 	return new Set(files);
 };
 
-const isRelativePath = (value: string) => value.startsWith('./');
-
-const normalizePath = (value: string) => value.slice(2);
-
-const hasWildcard = (value: string) => value.includes('*');
-
 const wildcardMatchesAnyFile = (
 	pattern: string,
 	publishedFiles: Set<string>,
 ) => {
-	const normalized = normalizePath(pattern);
+	const normalized = pattern.slice(2);
 	const prefix = normalized.slice(0, normalized.indexOf('*'));
 	const suffix = normalized.slice(normalized.indexOf('*') + 1);
 
-	for (const file of Array.from(publishedFiles)) {
-		if (file.startsWith(prefix) && file.endsWith(suffix)) {
-			return true;
-		}
-	}
-	return false;
+	return Array.from(publishedFiles).some(
+		file => file.startsWith(prefix) && file.endsWith(suffix),
+	);
 };
 
 // Sentinel to distinguish "prune this" from "value is literally null"
@@ -49,13 +40,13 @@ const pruneValue = (
 	}
 
 	if (typeof value === 'string') {
-		if (!isRelativePath(value)) {
+		if (!value.startsWith('./')) {
 			return value;
 		}
-		if (hasWildcard(value)) {
+		if (value.includes('*')) {
 			return wildcardMatchesAnyFile(value, publishedFiles) ? value : PRUNE;
 		}
-		return publishedFiles.has(normalizePath(value)) ? value : PRUNE;
+		return publishedFiles.has(value.slice(2)) ? value : PRUNE;
 	}
 
 	if (Array.isArray(value)) {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -376,6 +376,27 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
+	test('--no-prune disables path pruning', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#utils': './src/utils.ts',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path, ['--no-prune']);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.imports).toStrictEqual({
+			'#utils': './src/utils.ts',
+		});
+	});
+
 	test('non-path specifiers left untouched', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -376,7 +376,7 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('--prune=false disables path pruning', async () => {
+	test('--published-only=false disables path pruning', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
 			'package.json': JSON.stringify({
@@ -389,7 +389,7 @@ describe('prune unpublished paths', () => {
 			}),
 		});
 
-		await cleanPkgJson(fixture.path, ['--prune=false']);
+		await cleanPkgJson(fixture.path, ['--published-only=false']);
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.imports).toStrictEqual({

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -150,3 +150,159 @@ describe('clean-pkg-json', () => {
 		await expect(cleanPkgJson(fixture.path)).rejects.toThrow();
 	});
 });
+
+describe('prune unpublished paths', () => {
+	test('prunes import entry pointing to unpublished file', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#utils': './src/utils.ts',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result).not.toHaveProperty('imports');
+	});
+
+	test('preserves import entry pointing to published file', async () => {
+		await using fixture = await createFixture({
+			'dist/utils.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#utils': './dist/utils.js',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.imports).toStrictEqual({
+			'#utils': './dist/utils.js',
+		});
+	});
+
+	test('conditional import — prunes only unpublished branches', async () => {
+		await using fixture = await createFixture({
+			'dist/config.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#config': {
+						development: './src/config.dev.ts',
+						default: './dist/config.js',
+					},
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.imports).toStrictEqual({
+			'#config': {
+				default: './dist/config.js',
+			},
+		});
+	});
+
+	test('conditional import — removes entry when all branches unpublished', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#internal': {
+						development: './src/internal.dev.ts',
+						default: './src/internal.ts',
+					},
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result).not.toHaveProperty('imports');
+	});
+
+	test('exports — prunes unpublished branches', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': {
+						source: './src/index.ts',
+						default: './dist/index.js',
+					},
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': {
+				default: './dist/index.js',
+			},
+		});
+	});
+
+	test('bare string export — prunes if unpublished', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: './src/index.ts',
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result).not.toHaveProperty('exports');
+	});
+
+	test('non-path specifiers left untouched', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				imports: {
+					'#dep': 'lodash',
+					'#local': './dist/index.js',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.imports).toStrictEqual({
+			'#dep': 'lodash',
+			'#local': './dist/index.js',
+		});
+	});
+});

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -283,6 +283,99 @@ describe('prune unpublished paths', () => {
 		expect(result).not.toHaveProperty('exports');
 	});
 
+	test('null values preserved (used to block subpaths)', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./internal/*': null,
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': './dist/index.js',
+			'./internal/*': null,
+		});
+	});
+
+	test('fallback arrays — prunes unpublished entries', async () => {
+		await using fixture = await createFixture({
+			'dist/index.mjs': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': [
+						{ import: './dist/index.mjs' },
+						'./src/index.js',
+					],
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': [
+				{ import: './dist/index.mjs' },
+			],
+		});
+	});
+
+	test('wildcard patterns — preserved when matching files exist', async () => {
+		await using fixture = await createFixture({
+			'dist/utils/format.js': '',
+			'dist/utils/parse.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'./utils/*': './dist/utils/*.js',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'./utils/*': './dist/utils/*.js',
+		});
+	});
+
+	test('wildcard patterns — pruned when no matching files exist', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./utils/*': './src/utils/*.ts',
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': './dist/index.js',
+		});
+	});
+
 	test('non-path specifiers left untouched', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -376,7 +376,7 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('--no-prune disables path pruning', async () => {
+	test('--prune=false disables path pruning', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
 			'package.json': JSON.stringify({
@@ -389,7 +389,7 @@ describe('prune unpublished paths', () => {
 			}),
 		});
 
-		await cleanPkgJson(fixture.path, ['--no-prune']);
+		await cleanPkgJson(fixture.path, ['--prune=false']);
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.imports).toStrictEqual({


### PR DESCRIPTION
## Summary

Closes #5

- Uses npm-packlist to determine which files will be published
- Prunes `imports` and `exports` entries that reference non-published files
- For conditional imports/exports, only unpublished branches are pruned — published branches are preserved
- If all branches are unpublished, the entire entry is removed
- Handles `null` values (used to block subpaths), fallback arrays, and wildcard patterns
- `--published-only=false` flag to disable pruning
- README updated to document the behavior

## Test plan

- [x] Prunes import entry pointing to unpublished file
- [x] Preserves import entry pointing to published file
- [x] Conditional import — prunes only unpublished branches
- [x] Conditional import — removes entry when all branches unpublished
- [x] Exports — prunes unpublished branches
- [x] Bare string export — prunes if unpublished
- [x] Non-path specifiers (`"lodash"`) left untouched
- [x] `null` values preserved (used to block subpaths)
- [x] Fallback arrays — prunes unpublished entries
- [x] Wildcard patterns — preserved when matching files exist
- [x] Wildcard patterns — pruned when no matching files exist
- [x] `--published-only=false` disables path pruning