### PR TITLE
feat: warn when removing exports/imports entries for missing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Uses an allowlist to preserve only [properties relevant to package consumers](#d
 
 For `scripts`, only install hooks (`preinstall`, `install`, `postinstall`, `dependencies`) are preserved. All other scripts are removed.
 
-For `exports` and `imports`, entries pointing to files that exist locally but are excluded from the published package (e.g. source files referenced by dev-only conditions) are pruned. This prevents consumers from resolving to unpublished source files. Entries whose target files don't exist on disk (e.g. build artifacts that haven't been generated yet) are left untouched. Conditional entries are partially pruned — only the excluded branches are removed. Pass `--published-only=false` to disable this behavior.
+For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--published-only=false` to disable this behavior.
+
+If an entry is removed because its target file doesn't exist on disk, a warning is printed. This usually means `clean-pkg-json` ran before the build.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Uses an allowlist to preserve only [properties relevant to package consumers](#d
 
 For `scripts`, only install hooks (`preinstall`, `install`, `postinstall`, `dependencies`) are preserved. All other scripts are removed.
 
-For `exports` and `imports`, entries referencing files not included in the published package are pruned. This prevents consumers from resolving to non-existent source files. Conditional entries are partially pruned — only unpublished branches are removed. Pass `--published-only=false` to disable this behavior.
+For `exports` and `imports`, entries pointing to files that exist locally but are excluded from the published package (e.g. source files referenced by dev-only conditions) are pruned. This prevents consumers from resolving to unpublished source files. Entries whose target files don't exist on disk (e.g. build artifacts that haven't been generated yet) are left untouched. Conditional entries are partially pruned — only the excluded branches are removed. Pass `--published-only=false` to disable this behavior.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.19.15",
+		"ansis": "^4.3.1",
 		"cleye": "^2.3.0",
 		"fs-fixture": "^2.11.0",
 		"lintroll": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^22.19.15
         version: 22.19.15
+      ansis:
+        specifier: ^4.3.1
+        version: 4.3.1
       cleye:
         specifier: ^2.3.0
         version: 2.3.0
@@ -1024,6 +1027,10 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
+
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3703,6 +3710,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
+
+  ansis@4.3.1: {}
 
   argparse@1.0.10:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,21 @@ const log = (...args: any[]) => {
 	}
 };
 
+const parsePackageJson = (contents: string) => {
+	try {
+		return JSON.parse(contents);
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new Error(`Failed to parse ${packageJsonPath}: ${reason}`);
+	}
+};
+
+const reportError = (error: unknown) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(`${red('❌ Error:')} ${message}`);
+	process.exitCode = 1;
+};
+
 (async () => {
 	const isDryRun = argv.flags.dry || process.env.npm_config_dry_run === 'true';
 
@@ -59,13 +74,11 @@ const log = (...args: any[]) => {
 	);
 
 	if (!packageJsonExists) {
-		console.error(red(`${packageJsonPath} does not exist`));
-		process.exitCode = 1;
-		return;
+		throw new Error(`${packageJsonPath} does not exist`);
 	}
 
 	const packageJsonString = await fs.readFile(packageJsonPath, 'utf8');
-	const packageJson = JSON.parse(packageJsonString);
+	const packageJson = parsePackageJson(packageJsonString);
 
 	const keepProperties = new Set([
 		...defaultKeepProperties,
@@ -117,4 +130,4 @@ const log = (...args: any[]) => {
 		);
 		log(`Updated ${packageJsonPath}`);
 	}
-})();
+})().catch(reportError);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
-import { getLocalFiles, getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
+import { getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
 
 const { name, version, description } = pkg;
 
@@ -46,6 +46,41 @@ const argv = cli({
 const log = (...args: any[]) => {
 	if (argv.flags.verbose) {
 		console.log(...args);
+	}
+};
+
+const pruneUnpublishedFields = async (
+	packageJson: Record<string, unknown>,
+	fields: string[],
+) => {
+	const cwd = process.cwd();
+	const publishedFiles = await getPublishedFiles(cwd, packageJson);
+	const missingFiles = new Set<string>();
+
+	for (const field of fields) {
+		const { result, removedMissingFiles } = pruneUnpublishedPaths(
+			packageJson[field],
+			publishedFiles,
+			cwd,
+		);
+		for (const file of removedMissingFiles) {
+			missingFiles.add(file);
+		}
+
+		if (result === undefined) {
+			log(`Removing property "${field}" (no published files referenced)`);
+			delete packageJson[field];
+		} else {
+			packageJson[field] = result;
+		}
+	}
+
+	if (missingFiles.size > 0) {
+		console.warn(
+			'clean-pkg-json: removed exports/imports entries pointing to files that '
+			+ `don't exist: ${Array.from(missingFiles).join(', ')}\n`
+			+ 'If these are build outputs, run clean-pkg-json after building.',
+		);
 	}
 };
 
@@ -102,19 +137,7 @@ const log = (...args: any[]) => {
 		? ['imports', 'exports'].filter(field => packageJson[field])
 		: [];
 	if (fieldsToPrune.length > 0) {
-		const [publishedFiles, localFiles] = await Promise.all([
-			getPublishedFiles(process.cwd(), packageJson),
-			getLocalFiles(process.cwd()),
-		]);
-		for (const field of fieldsToPrune) {
-			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles, localFiles);
-			if (pruned === undefined) {
-				log(`Removing property "${field}" (no published files referenced)`);
-				delete packageJson[field];
-			} else {
-				packageJson[field] = pruned;
-			}
-		}
+		await pruneUnpublishedFields(packageJson, fieldsToPrune);
 	}
 
 	const newPackageJsonString = JSON.stringify(packageJson, null, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ const parsePackageJson = (contents: string) => {
 
 const reportError = (error: unknown) => {
 	const message = error instanceof Error ? error.message : String(error);
-	console.error(`${red('❌ Error:')} ${message}`);
+	console.error(`${red('Error:')} ${message}`);
 	process.exitCode = 1;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
-import { getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
+import { getLocalFiles, getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
 
 const { name, version, description } = pkg;
 
@@ -54,14 +54,17 @@ const pruneUnpublishedFields = async (
 	fields: string[],
 ) => {
 	const cwd = process.cwd();
-	const publishedFiles = await getPublishedFiles(cwd, packageJson);
+	const [publishedFiles, localFiles] = await Promise.all([
+		getPublishedFiles(cwd, packageJson),
+		getLocalFiles(cwd),
+	]);
 	const missingFiles = new Set<string>();
 
 	for (const field of fields) {
 		const { result, removedMissingFiles } = pruneUnpublishedPaths(
 			packageJson[field],
 			publishedFiles,
-			cwd,
+			localFiles,
 		);
 		for (const file of removedMissingFiles) {
 			missingFiles.add(file);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import { red } from 'ansis';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
@@ -58,7 +59,9 @@ const log = (...args: any[]) => {
 	);
 
 	if (!packageJsonExists) {
-		throw new Error(`${packageJsonPath} does not exist`);
+		console.error(red(`${packageJsonPath} does not exist`));
+		process.exitCode = 1;
+		return;
 	}
 
 	const packageJsonString = await fs.readFile(packageJsonPath, 'utf8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
-import { getLocalFiles, getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
+import { pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
 
 const { name, version, description } = pkg;
 
@@ -46,44 +46,6 @@ const argv = cli({
 const log = (...args: any[]) => {
 	if (argv.flags.verbose) {
 		console.log(...args);
-	}
-};
-
-const pruneUnpublishedFields = async (
-	packageJson: Record<string, unknown>,
-	fields: string[],
-) => {
-	const cwd = process.cwd();
-	const [publishedFiles, localFiles] = await Promise.all([
-		getPublishedFiles(cwd, packageJson),
-		getLocalFiles(cwd),
-	]);
-	const missingFiles = new Set<string>();
-
-	for (const field of fields) {
-		const { result, removedMissingFiles } = pruneUnpublishedPaths(
-			packageJson[field],
-			publishedFiles,
-			localFiles,
-		);
-		for (const file of removedMissingFiles) {
-			missingFiles.add(file);
-		}
-
-		if (result === undefined) {
-			log(`Removing property "${field}" (no published files referenced)`);
-			delete packageJson[field];
-		} else {
-			packageJson[field] = result;
-		}
-	}
-
-	if (missingFiles.size > 0) {
-		console.warn(
-			'clean-pkg-json: removed exports/imports entries pointing to files that '
-			+ `don't exist: ${Array.from(missingFiles).join(', ')}\n`
-			+ 'If these are build outputs, run clean-pkg-json after building.',
-		);
 	}
 };
 
@@ -136,11 +98,8 @@ const pruneUnpublishedFields = async (
 		delete packageJson[property];
 	}
 
-	const fieldsToPrune = argv.flags.publishedOnly
-		? ['imports', 'exports'].filter(field => packageJson[field])
-		: [];
-	if (fieldsToPrune.length > 0) {
-		await pruneUnpublishedFields(packageJson, fieldsToPrune);
+	if (argv.flags.publishedOnly) {
+		await pruneUnpublishedPaths(process.cwd(), packageJson, log);
 	}
 
 	const newPackageJsonString = JSON.stringify(packageJson, null, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import { cli } from 'cleye';
 import pkg from '../package.json' with { type: 'json' };
 import { defaultKeepProperties } from './default-keep-properties.ts';
-import { getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
+import { getLocalFiles, getPublishedFiles, pruneUnpublishedPaths } from './prune-unpublished-paths.ts';
 
 const { name, version, description } = pkg;
 
@@ -102,9 +102,12 @@ const log = (...args: any[]) => {
 		? ['imports', 'exports'].filter(field => packageJson[field])
 		: [];
 	if (fieldsToPrune.length > 0) {
-		const publishedFiles = await getPublishedFiles(process.cwd(), packageJson);
+		const [publishedFiles, localFiles] = await Promise.all([
+			getPublishedFiles(process.cwd(), packageJson),
+			getLocalFiles(process.cwd()),
+		]);
 		for (const field of fieldsToPrune) {
-			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles);
+			const pruned = pruneUnpublishedPaths(packageJson[field], publishedFiles, localFiles);
 			if (pruned === undefined) {
 				log(`Removing property "${field}" (no published files referenced)`);
 				delete packageJson[field];

--- a/src/path-matcher.ts
+++ b/src/path-matcher.ts
@@ -74,20 +74,21 @@ export const pathMatches = (
 		return filePath === segments[0];
 	}
 
-	// Single star (the common case): prefix + value + suffix. The length guard
-	// rejects paths too short to fit a non-overlapping prefix and suffix.
+	// Single star (the common case): prefix + value + suffix. `>` (not `>=`)
+	// because Node requires the `*` to capture at least one character.
 	if (starCount === 1) {
 		return (
-			filePath.length >= literalLength
+			filePath.length > literalLength
 			&& filePath.startsWith(segments[0])
 			&& filePath.endsWith(segments[1])
 		);
 	}
 
 	// Multiple stars all bind to the same value, so its length is determined by
-	// the leftover after the literals.
+	// the leftover after the literals. Each star must capture at least one
+	// character (value length >= 1), so the leftover must be at least starCount.
 	const valueTotal = filePath.length - literalLength;
-	if (valueTotal < 0 || valueTotal % starCount !== 0) {
+	if (valueTotal < starCount || valueTotal % starCount !== 0) {
 		return false;
 	}
 

--- a/src/path-matcher.ts
+++ b/src/path-matcher.ts
@@ -1,0 +1,70 @@
+const STAR = '*';
+
+export type PathMatcher = {
+	prefix: string;
+	middle: string[];
+	suffix: string;
+};
+
+/**
+ * Parses a `*` pattern (e.g. `dist/*.js`) into prefix/middle/suffix segments
+ * once, so it can be matched against many file paths cheaply.
+ */
+export const createPathMatcher = (
+	pattern: string,
+): PathMatcher => {
+	const segments = pattern.split(STAR);
+	const lastIndex = segments.length - 1;
+	return {
+		prefix: segments[0],
+		middle: segments.slice(1, lastIndex),
+		suffix: segments[lastIndex],
+	};
+};
+
+/**
+ * Matches a file path against a parsed pattern, returning the `*` capture
+ * (which may be an empty string) or `undefined` when it doesn't match. Multiple
+ * stars must capture the same value.
+ */
+export const pathMatches = (
+	{ prefix, middle, suffix }: PathMatcher,
+	filePath: string,
+): string | undefined => {
+	if (
+		!filePath.startsWith(prefix)
+		|| !filePath.endsWith(suffix)
+	) {
+		return;
+	}
+
+	const inner = filePath.slice(prefix.length, -suffix.length || undefined);
+	if (middle.length === 0) {
+		return inner;
+	}
+
+	let lastIndex = 0;
+	let starValue = '';
+	for (const segment of middle) {
+		const segmentIndex = inner.indexOf(segment, lastIndex);
+		if (segmentIndex === -1) {
+			return;
+		}
+
+		const extracted = inner.slice(lastIndex, segmentIndex);
+		if (!starValue) {
+			starValue = extracted;
+		} else if (starValue !== extracted) {
+			return;
+		}
+
+		lastIndex = segmentIndex + segment.length;
+	}
+
+	// The final star (after the last fixed segment) must match the same value.
+	if (inner.slice(lastIndex) !== starValue) {
+		return;
+	}
+
+	return starValue;
+};

--- a/src/path-matcher.ts
+++ b/src/path-matcher.ts
@@ -1,70 +1,95 @@
 const STAR = '*';
 
 export type PathMatcher = {
-	prefix: string;
-	middle: string[];
-	suffix: string;
+	// Literal parts of the pattern, split on `*`.
+	segments: string[];
+
+	// Number of `*` (segments.length - 1).
+	starCount: number;
+
+	// Combined length of all literal segments.
+	literalLength: number;
 };
 
-/**
- * Parses a `*` pattern (e.g. `dist/*.js`) into prefix/middle/suffix segments
- * once, so it can be matched against many file paths cheaply.
- */
 export const createPathMatcher = (
 	pattern: string,
 ): PathMatcher => {
 	const segments = pattern.split(STAR);
-	const lastIndex = segments.length - 1;
+	let literalLength = 0;
+	for (const segment of segments) {
+		literalLength += segment.length;
+	}
+
 	return {
-		prefix: segments[0],
-		middle: segments.slice(1, lastIndex),
-		suffix: segments[lastIndex],
+		segments,
+		starCount: segments.length - 1,
+		literalLength,
 	};
 };
 
 /**
- * Matches a file path against a parsed pattern, returning the `*` capture
- * (which may be an empty string) or `undefined` when it doesn't match. Multiple
- * stars must capture the same value.
+ * Places each literal segment at its fixed offset (given the per-star value
+ * length) and confirms every captured slice is identical.
+ */
+const segmentsAlign = (
+	segments: string[],
+	starCount: number,
+	valueLength: number,
+	filePath: string,
+) => {
+	let position = 0;
+	let value: string | undefined;
+	for (let index = 0; index < segments.length; index += 1) {
+		const segment = segments[index];
+		if (!filePath.startsWith(segment, position)) {
+			return false;
+		}
+		position += segment.length;
+
+		// A captured value follows every segment except the last.
+		if (index < starCount) {
+			const captured = filePath.slice(position, position + valueLength);
+			if (value === undefined) {
+				value = captured;
+			} else if (value !== captured) {
+				return false;
+			}
+			position += valueLength;
+		}
+	}
+
+	return position === filePath.length;
+};
+
+/**
+ * Whether a file path is a possible expansion of a `*` pattern. Per Node's
+ * resolution, every `*` is replaced by the same captured value (which may
+ * contain `/`), so the matched value's length is fixed by the path length.
  */
 export const pathMatches = (
-	{ prefix, middle, suffix }: PathMatcher,
+	{ segments, starCount, literalLength }: PathMatcher,
 	filePath: string,
-): string | undefined => {
-	if (
-		!filePath.startsWith(prefix)
-		|| !filePath.endsWith(suffix)
-	) {
-		return;
+): boolean => {
+	if (starCount === 0) {
+		return filePath === segments[0];
 	}
 
-	const inner = filePath.slice(prefix.length, -suffix.length || undefined);
-	if (middle.length === 0) {
-		return inner;
+	// Single star (the common case): prefix + value + suffix. The length guard
+	// rejects paths too short to fit a non-overlapping prefix and suffix.
+	if (starCount === 1) {
+		return (
+			filePath.length >= literalLength
+			&& filePath.startsWith(segments[0])
+			&& filePath.endsWith(segments[1])
+		);
 	}
 
-	let lastIndex = 0;
-	let starValue = '';
-	for (const segment of middle) {
-		const segmentIndex = inner.indexOf(segment, lastIndex);
-		if (segmentIndex === -1) {
-			return;
-		}
-
-		const extracted = inner.slice(lastIndex, segmentIndex);
-		if (!starValue) {
-			starValue = extracted;
-		} else if (starValue !== extracted) {
-			return;
-		}
-
-		lastIndex = segmentIndex + segment.length;
+	// Multiple stars all bind to the same value, so its length is determined by
+	// the leftover after the literals.
+	const valueTotal = filePath.length - literalLength;
+	if (valueTotal < 0 || valueTotal % starCount !== 0) {
+		return false;
 	}
 
-	// The final star (after the last fixed segment) must match the same value.
-	if (inner.slice(lastIndex) !== starValue) {
-		return;
-	}
-
-	return starValue;
+	return segmentsAlign(segments, starCount, valueTotal / starCount, filePath);
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -38,7 +38,7 @@ const specifierMatches = (
 
 	const matcher = createPathMatcher(target);
 	return Array.from(files).some(
-		file => pathMatches(matcher, file) !== undefined,
+		file => pathMatches(matcher, file),
 	);
 };
 
@@ -158,8 +158,11 @@ const findMissingFiles = async (
 		let exists: boolean;
 		if (target.includes('*')) {
 			const matcher = createPathMatcher(target);
-			const lastSlash = matcher.prefix.lastIndexOf('/');
-			const scope = lastSlash === -1 ? '.' : matcher.prefix.slice(0, lastSlash);
+			// The literal prefix (before the first `*`) bounds the directory we
+			// need to scan, so we never read the whole tree.
+			const prefix = matcher.segments[0];
+			const lastSlash = prefix.lastIndexOf('/');
+			const scope = lastSlash === -1 ? '.' : prefix.slice(0, lastSlash);
 			const directory = path.resolve(cwd, scope);
 
 			let files = directoryCache.get(directory);
@@ -167,7 +170,7 @@ const findMissingFiles = async (
 				files = await listFilesUnder(fs, cwd, directory);
 				directoryCache.set(directory, files);
 			}
-			exists = files.some(file => pathMatches(matcher, file) !== undefined);
+			exists = files.some(file => pathMatches(matcher, file));
 		} else {
 			exists = await fileExists(fs, path.resolve(cwd, target));
 		}

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -110,32 +110,46 @@ const fileExists = async (
 	}
 };
 
+const ignoredDirectories = new Set(['node_modules', '.git']);
+
 /**
- * Lists files (posix paths relative to `cwd`) under a directory. Returns an
- * empty list if the directory doesn't exist. Best-effort: never throws.
+ * Lists files (posix paths relative to `cwd`) under a directory, skipping
+ * `node_modules`/`.git` (which can't appear in export targets and would bloat
+ * the scan). Returns an empty list if the directory doesn't exist; never throws.
  */
 const listFilesUnder = async (
 	fs: FileSystem,
 	cwd: string,
 	directory: string,
 ) => {
-	let entries;
-	try {
-		entries = await fs.readdir(directory, {
-			recursive: true,
-			withFileTypes: true,
-		});
-	} catch {
-		return [];
-	}
-
 	const files: string[] = [];
-	for (const entry of entries) {
-		if (entry.isFile()) {
-			const filePath = path.relative(cwd, path.join(entry.parentPath, entry.name));
-			files.push(filePath.split(path.sep).join('/'));
+
+	const walk = async (current: string) => {
+		let entries;
+		try {
+			entries = await fs.readdir(current, { withFileTypes: true });
+		} catch {
+			return;
 		}
-	}
+
+		await Promise.all(
+			entries.map(async (entry) => {
+				if (entry.isDirectory()) {
+					if (!ignoredDirectories.has(entry.name)) {
+						await walk(path.join(current, entry.name));
+					}
+					return;
+				}
+
+				if (entry.isFile()) {
+					const filePath = path.relative(cwd, path.join(current, entry.name));
+					files.push(filePath.split(path.sep).join('/'));
+				}
+			}),
+		);
+	};
+
+	await walk(directory);
 	return files;
 };
 

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,5 +1,6 @@
 import { promises as nodeFs } from 'node:fs';
 import path from 'node:path';
+import { yellow } from 'ansis';
 import packlist from 'npm-packlist';
 import { createPathMatcher, pathMatches } from './path-matcher.ts';
 
@@ -213,11 +214,11 @@ const findMissingFiles = async (
 };
 
 const warnMissingFiles = (missingFiles: Set<string>) => {
-	console.warn(
-		'clean-pkg-json: removed exports/imports entries pointing to files that '
+	console.warn(yellow(
+		'Removed exports/imports entries pointing to files that '
 		+ `don't exist: ${Array.from(missingFiles).join(', ')}\n`
-		+ 'If these are build outputs, run clean-pkg-json after building.',
-	);
+		+ 'If these are build outputs, build the package first.',
+	));
 };
 
 /**

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,7 +1,7 @@
 import { promises as nodeFs } from 'node:fs';
 import path from 'node:path';
 import {
-	cyan, green, magenta, yellow,
+	cyan, gray, magenta, yellow,
 } from 'ansis';
 import packlist from 'npm-packlist';
 import { createPathMatcher, pathMatches } from './path-matcher.ts';
@@ -297,7 +297,7 @@ const warnRemovedEntry = ({ subpath, conditions, target }: RemovedEntry) => {
 		: '';
 	console.warn(
 		`${yellow('⚠️ Warning:')} ${cyan(subpath)}${conditionsText} `
-		+ `was removed because ${green(target)} doesn't exist`,
+		+ `was removed because ${gray.dim(target)} doesn't exist`,
 	);
 };
 

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,6 +1,8 @@
 import { promises as nodeFs } from 'node:fs';
 import path from 'node:path';
-import { yellow } from 'ansis';
+import {
+	cyan, green, magenta, yellow,
+} from 'ansis';
 import packlist from 'npm-packlist';
 import { createPathMatcher, pathMatches } from './path-matcher.ts';
 
@@ -291,11 +293,11 @@ const findMissingEntries = async (
 
 const warnRemovedEntry = ({ subpath, conditions, target }: RemovedEntry) => {
 	const conditionsText = conditions.length > 0
-		? ` with conditions ${conditions.join(' + ')}`
+		? ` with conditions ${magenta(conditions.join(' + '))}`
 		: '';
 	console.warn(
-		`${yellow('⚠️ Warning:')} ${subpath}${conditionsText} `
-		+ `was removed because ${target} doesn't exist`,
+		`${yellow('⚠️ Warning:')} ${cyan(subpath)}${conditionsText} `
+		+ `was removed because ${green(target)} doesn't exist`,
 	);
 };
 

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -296,7 +296,7 @@ const warnRemovedEntry = ({ subpath, conditions, target }: RemovedEntry) => {
 		? ` with conditions ${magenta(conditions.join(' + '))}`
 		: '';
 	console.warn(
-		`${yellow('⚠️ Warning:')} ${cyan(subpath)}${conditionsText} `
+		`${yellow('Warning:')} ${cyan(subpath)}${conditionsText} `
 		+ `was removed because ${dim(target)} doesn't exist`,
 	);
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,6 +1,9 @@
-import { readdir } from 'node:fs/promises';
+import { promises as nodeFs } from 'node:fs';
 import path from 'node:path';
 import packlist from 'npm-packlist';
+import { createPathMatcher, pathMatches } from './path-matcher.ts';
+
+type FileSystem = Pick<typeof nodeFs, 'stat' | 'readdir'>;
 
 const edgesOut = new Map();
 
@@ -20,124 +23,161 @@ const getPublishedFiles = async (
 	return new Set(files);
 };
 
-const ignoredDirectories = new Set(['node_modules', '.git']);
+/**
+ * Whether a `./`-relative specifier resolves to a file in the set. The set
+ * holds posix paths without the leading `./`.
+ */
+const specifierMatches = (
+	specifier: string,
+	files: Set<string>,
+) => {
+	const target = specifier.slice(2);
+	if (!target.includes('*')) {
+		return files.has(target);
+	}
+
+	const matcher = createPathMatcher(target);
+	return Array.from(files).some(
+		file => pathMatches(matcher, file) !== undefined,
+	);
+};
 
 /**
- * Files that exist on disk, as posix relative paths. Lets us tell files that
- * are excluded from the published package apart from files that don't exist
- * yet (e.g. build artifacts that haven't been generated).
+ * Recursively prunes `exports`/`imports` values, dropping `./`-relative
+ * specifiers that won't be published. Returns the pruned value (or `undefined`
+ * when nothing is left) along with the specifiers that were dropped.
  */
-const getLocalFiles = async (cwd: string) => {
-	const files = new Set<string>();
+const prunePaths = (
+	value: unknown,
+	publishedFiles: Set<string>,
+) => {
+	const prunedSpecifiers: string[] = [];
 
-	const walk = async (directory: string) => {
-		const entries = await readdir(directory, { withFileTypes: true });
-		await Promise.all(
-			entries.map(async (entry) => {
-				if (entry.isDirectory()) {
-					if (!ignoredDirectories.has(entry.name)) {
-						await walk(path.join(directory, entry.name));
-					}
-					return;
-				}
-
-				if (entry.isFile()) {
-					const relativePath = path.relative(cwd, path.join(directory, entry.name));
-					files.add(relativePath.split(path.sep).join('/'));
-				}
-			}),
-		);
+	const pruneSpecifier = (specifier: string) => {
+		if (!specifier.startsWith('./')) {
+			return specifier;
+		}
+		if (specifierMatches(specifier, publishedFiles)) {
+			return specifier;
+		}
+		prunedSpecifiers.push(specifier);
+		return undefined;
 	};
 
-	await walk(cwd);
+	const prune = (node: unknown): unknown | undefined => {
+		if (node === null) {
+			return null;
+		}
+
+		if (typeof node === 'string') {
+			return pruneSpecifier(node);
+		}
+
+		if (Array.isArray(node)) {
+			const kept = node.map(prune).filter(item => item !== undefined);
+			return kept.length > 0 ? kept : undefined;
+		}
+
+		if (typeof node === 'object') {
+			const kept: Record<string, unknown> = {};
+			for (const [key, child] of Object.entries(node)) {
+				const pruned = prune(child);
+				if (pruned !== undefined) {
+					kept[key] = pruned;
+				}
+			}
+			return Object.keys(kept).length > 0 ? kept : undefined;
+		}
+
+		return node;
+	};
+
+	return {
+		result: prune(value),
+		prunedSpecifiers,
+	};
+};
+
+const fileExists = async (
+	fs: FileSystem,
+	filePath: string,
+) => {
+	try {
+		await fs.stat(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Lists files (posix paths relative to `cwd`) under a directory. Returns an
+ * empty list if the directory doesn't exist. Best-effort: never throws.
+ */
+const listFilesUnder = async (
+	fs: FileSystem,
+	cwd: string,
+	directory: string,
+) => {
+	let entries;
+	try {
+		entries = await fs.readdir(directory, {
+			recursive: true,
+			withFileTypes: true,
+		});
+	} catch {
+		return [];
+	}
+
+	const files: string[] = [];
+	for (const entry of entries) {
+		if (entry.isFile()) {
+			const filePath = path.relative(cwd, path.join(entry.parentPath, entry.name));
+			files.push(filePath.split(path.sep).join('/'));
+		}
+	}
 	return files;
 };
 
 /**
- * Whether a `./`-relative specifier resolves to any file in the set. Handles
- * both exact paths and `*` wildcard patterns (matched by prefix and suffix).
+ * Of the dropped specifiers, finds the ones whose target file doesn't exist on
+ * disk (likely an unbuilt artifact, rather than a deliberately excluded source
+ * file). Only touches the filesystem within the referenced scopes.
  */
-const pathMatchesFile = (
-	specifier: string,
-	files: Set<string>,
+const findMissingFiles = async (
+	fs: FileSystem,
+	cwd: string,
+	prunedSpecifiers: string[],
 ) => {
-	const normalized = specifier.slice(2);
-	const star = normalized.indexOf('*');
-	if (star === -1) {
-		return files.has(normalized);
-	}
+	const missingFiles = new Set<string>();
+	const directoryCache = new Map<string, string[]>();
 
-	const prefix = normalized.slice(0, star);
-	const suffix = normalized.slice(star + 1);
-	return Array.from(files).some(
-		file => file.startsWith(prefix) && file.endsWith(suffix),
-	);
-};
+	for (const specifier of prunedSpecifiers) {
+		const target = specifier.slice(2);
 
-type PruneContext = {
-	publishedFiles: Set<string>;
-	localFiles: Set<string>;
+		let exists: boolean;
+		if (target.includes('*')) {
+			const matcher = createPathMatcher(target);
+			const lastSlash = matcher.prefix.lastIndexOf('/');
+			const scope = lastSlash === -1 ? '.' : matcher.prefix.slice(0, lastSlash);
+			const directory = path.resolve(cwd, scope);
 
-	// Removed specifiers with no on-disk match, collected for the warning.
-	missingFiles: Set<string>;
-};
-
-/**
- * Decides the fate of a single `./`-relative specifier: kept if it will be
- * published, otherwise dropped (and flagged as missing when nothing matches it
- * on disk). Non-relative specifiers (e.g. bare package names) are left as-is.
- */
-const pruneSpecifier = (
-	specifier: string,
-	context: PruneContext,
-) => {
-	if (!specifier.startsWith('./')) {
-		return specifier;
-	}
-	if (pathMatchesFile(specifier, context.publishedFiles)) {
-		return specifier;
-	}
-	if (!pathMatchesFile(specifier, context.localFiles)) {
-		context.missingFiles.add(specifier);
-	}
-	return undefined;
-};
-
-/**
- * Recursively prunes `exports`/`imports` values, dropping specifiers that won't
- * be published. Returns the pruned value, or `undefined` when nothing is left.
- */
-const prunePaths = (
-	value: unknown,
-	context: PruneContext,
-): unknown | undefined => {
-	if (value === null) {
-		return null;
-	}
-
-	if (typeof value === 'string') {
-		return pruneSpecifier(value, context);
-	}
-
-	if (Array.isArray(value)) {
-		const kept = value
-			.map(item => prunePaths(item, context))
-			.filter(item => item !== undefined);
-		return kept.length > 0 ? kept : undefined;
-	}
-
-	if (typeof value === 'object') {
-		const kept: Record<string, unknown> = {};
-		for (const [key, child] of Object.entries(value)) {
-			const pruned = prunePaths(child, context);
-			if (pruned !== undefined) {
-				kept[key] = pruned;
+			let files = directoryCache.get(directory);
+			if (!files) {
+				files = await listFilesUnder(fs, cwd, directory);
+				directoryCache.set(directory, files);
 			}
+			exists = files.some(file => pathMatches(matcher, file) !== undefined);
+		} else {
+			exists = await fileExists(fs, path.resolve(cwd, target));
 		}
-		return Object.keys(kept).length > 0 ? kept : undefined;
+
+		if (!exists) {
+			missingFiles.add(specifier);
+		}
 	}
 
-	return value;
+	return missingFiles;
 };
 
 const warnMissingFiles = (missingFiles: Set<string>) => {
@@ -157,33 +197,36 @@ export const pruneUnpublishedPaths = async (
 	cwd: string,
 	packageJson: Record<string, unknown>,
 	log: (message: string) => void,
+	fs: FileSystem = nodeFs,
 ) => {
 	const fields = ['imports', 'exports'].filter(field => packageJson[field]);
 	if (fields.length === 0) {
 		return;
 	}
 
-	const [publishedFiles, localFiles] = await Promise.all([
-		getPublishedFiles(cwd, packageJson),
-		getLocalFiles(cwd),
-	]);
-	const context: PruneContext = {
-		publishedFiles,
-		localFiles,
-		missingFiles: new Set(),
-	};
+	const publishedFiles = await getPublishedFiles(cwd, packageJson);
 
+	const prunedSpecifiers = new Set<string>();
 	for (const field of fields) {
-		const pruned = prunePaths(packageJson[field], context);
-		if (pruned === undefined) {
+		const { result, prunedSpecifiers: dropped } = prunePaths(packageJson[field], publishedFiles);
+		for (const specifier of dropped) {
+			prunedSpecifiers.add(specifier);
+		}
+
+		if (result === undefined) {
 			log(`Removing property "${field}" (no published files referenced)`);
 			delete packageJson[field];
 		} else {
-			packageJson[field] = pruned;
+			packageJson[field] = result;
 		}
 	}
 
-	if (context.missingFiles.size > 0) {
-		warnMissingFiles(context.missingFiles);
+	if (prunedSpecifiers.size === 0) {
+		return;
+	}
+
+	const missingFiles = await findMissingFiles(fs, cwd, Array.from(prunedSpecifiers));
+	if (missingFiles.size > 0) {
+		warnMissingFiles(missingFiles);
 	}
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,7 +1,7 @@
 import { promises as nodeFs } from 'node:fs';
 import path from 'node:path';
 import {
-	cyan, gray, magenta, yellow,
+	cyan, dim, magenta, yellow,
 } from 'ansis';
 import packlist from 'npm-packlist';
 import { createPathMatcher, pathMatches } from './path-matcher.ts';
@@ -297,7 +297,7 @@ const warnRemovedEntry = ({ subpath, conditions, target }: RemovedEntry) => {
 		: '';
 	console.warn(
 		`${yellow('⚠️ Warning:')} ${cyan(subpath)}${conditionsText} `
-		+ `was removed because ${gray.dim(target)} doesn't exist`,
+		+ `was removed because ${dim(target)} doesn't exist`,
 	);
 };
 

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -4,7 +4,10 @@ import packlist from 'npm-packlist';
 
 const edgesOut = new Map();
 
-export const getPublishedFiles = async (
+/**
+ * Files that will be included in the published package, as posix relative paths.
+ */
+const getPublishedFiles = async (
 	cwd: string,
 	packageJson: Record<string, unknown>,
 ) => {
@@ -20,12 +23,11 @@ export const getPublishedFiles = async (
 const ignoredDirectories = new Set(['node_modules', '.git']);
 
 /**
- * All files that exist on disk, as posix relative paths (matching the format
- * returned by npm-packlist). Used to tell files that are excluded from the
- * published package apart from files that simply don't exist yet (e.g. build
- * artifacts that haven't been generated).
+ * Files that exist on disk, as posix relative paths. Lets us tell files that
+ * are excluded from the published package apart from files that don't exist
+ * yet (e.g. build artifacts that haven't been generated).
  */
-export const getLocalFiles = async (cwd: string) => {
+const getLocalFiles = async (cwd: string) => {
 	const files = new Set<string>();
 
 	const walk = async (directory: string) => {
@@ -51,83 +53,137 @@ export const getLocalFiles = async (cwd: string) => {
 	return files;
 };
 
-const wildcardMatchesAnyFile = (
-	pattern: string,
+/**
+ * Whether a `./`-relative specifier resolves to any file in the set. Handles
+ * both exact paths and `*` wildcard patterns (matched by prefix and suffix).
+ */
+const pathMatchesFile = (
+	specifier: string,
 	files: Set<string>,
 ) => {
-	const normalized = pattern.slice(2);
-	const prefix = normalized.slice(0, normalized.indexOf('*'));
-	const suffix = normalized.slice(normalized.indexOf('*') + 1);
+	const normalized = specifier.slice(2);
+	const star = normalized.indexOf('*');
+	if (star === -1) {
+		return files.has(normalized);
+	}
 
+	const prefix = normalized.slice(0, star);
+	const suffix = normalized.slice(star + 1);
 	return Array.from(files).some(
 		file => file.startsWith(prefix) && file.endsWith(suffix),
 	);
 };
 
-export const pruneUnpublishedPaths = (
-	value: unknown,
-	publishedFiles: Set<string>,
-	localFiles: Set<string>,
+type PruneContext = {
+	publishedFiles: Set<string>;
+	localFiles: Set<string>;
+
+	// Removed specifiers with no on-disk match, collected for the warning.
+	missingFiles: Set<string>;
+};
+
+/**
+ * Decides the fate of a single `./`-relative specifier: kept if it will be
+ * published, otherwise dropped (and flagged as missing when nothing matches it
+ * on disk). Non-relative specifiers (e.g. bare package names) are left as-is.
+ */
+const pruneSpecifier = (
+	specifier: string,
+	context: PruneContext,
 ) => {
-	// Paths removed even though nothing matches on disk, likely unbuilt
-	// artifacts rather than deliberately excluded source files.
-	const removedMissingFiles: string[] = [];
+	if (!specifier.startsWith('./')) {
+		return specifier;
+	}
+	if (pathMatchesFile(specifier, context.publishedFiles)) {
+		return specifier;
+	}
+	if (!pathMatchesFile(specifier, context.localFiles)) {
+		context.missingFiles.add(specifier);
+	}
+	return undefined;
+};
 
-	const pruneString = (node: string) => {
-		if (!node.startsWith('./')) {
-			return node;
-		}
+/**
+ * Recursively prunes `exports`/`imports` values, dropping specifiers that won't
+ * be published. Returns the pruned value, or `undefined` when nothing is left.
+ */
+const prunePaths = (
+	value: unknown,
+	context: PruneContext,
+): unknown | undefined => {
+	if (value === null) {
+		return null;
+	}
 
-		if (node.includes('*')) {
-			if (wildcardMatchesAnyFile(node, publishedFiles)) {
-				return node;
+	if (typeof value === 'string') {
+		return pruneSpecifier(value, context);
+	}
+
+	if (Array.isArray(value)) {
+		const kept = value
+			.map(item => prunePaths(item, context))
+			.filter(item => item !== undefined);
+		return kept.length > 0 ? kept : undefined;
+	}
+
+	if (typeof value === 'object') {
+		const kept: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(value)) {
+			const pruned = prunePaths(child, context);
+			if (pruned !== undefined) {
+				kept[key] = pruned;
 			}
-			if (!wildcardMatchesAnyFile(node, localFiles)) {
-				removedMissingFiles.push(node);
-			}
-			return undefined;
 		}
+		return Object.keys(kept).length > 0 ? kept : undefined;
+	}
 
-		const filePath = node.slice(2);
-		if (publishedFiles.has(filePath)) {
-			return node;
-		}
-		if (!localFiles.has(filePath)) {
-			removedMissingFiles.push(node);
-		}
-		return undefined;
+	return value;
+};
+
+const warnMissingFiles = (missingFiles: Set<string>) => {
+	console.warn(
+		'clean-pkg-json: removed exports/imports entries pointing to files that '
+		+ `don't exist: ${Array.from(missingFiles).join(', ')}\n`
+		+ 'If these are build outputs, run clean-pkg-json after building.',
+	);
+};
+
+/**
+ * Prunes `imports`/`exports` entries that point to files which won't be in the
+ * published package, mutating `packageJson` in place. Warns about entries
+ * removed because their target file doesn't exist on disk (likely unbuilt).
+ */
+export const pruneUnpublishedPaths = async (
+	cwd: string,
+	packageJson: Record<string, unknown>,
+	log: (message: string) => void,
+) => {
+	const fields = ['imports', 'exports'].filter(field => packageJson[field]);
+	if (fields.length === 0) {
+		return;
+	}
+
+	const [publishedFiles, localFiles] = await Promise.all([
+		getPublishedFiles(cwd, packageJson),
+		getLocalFiles(cwd),
+	]);
+	const context: PruneContext = {
+		publishedFiles,
+		localFiles,
+		missingFiles: new Set(),
 	};
 
-	const prune = (node: unknown): unknown | undefined => {
-		if (node === null) {
-			return null;
+	for (const field of fields) {
+		const pruned = prunePaths(packageJson[field], context);
+		if (pruned === undefined) {
+			log(`Removing property "${field}" (no published files referenced)`);
+			delete packageJson[field];
+		} else {
+			packageJson[field] = pruned;
 		}
+	}
 
-		if (typeof node === 'string') {
-			return pruneString(node);
-		}
-
-		if (Array.isArray(node)) {
-			const kept = node.map(prune).filter(item => item !== undefined);
-			return kept.length > 0 ? kept : undefined;
-		}
-
-		if (typeof node === 'object') {
-			const kept: Record<string, unknown> = {};
-			for (const [key, child] of Object.entries(node)) {
-				const pruned = prune(child);
-				if (pruned !== undefined) {
-					kept[key] = pruned;
-				}
-			}
-			return Object.keys(kept).length > 0 ? kept : undefined;
-		}
-
-		return node;
-	};
-
-	return {
-		result: prune(value),
-		removedMissingFiles,
-	};
+	if (context.missingFiles.size > 0) {
+		warnMissingFiles(context.missingFiles);
+	}
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
 import path from 'node:path';
 import packlist from 'npm-packlist';
 
@@ -17,15 +17,49 @@ export const getPublishedFiles = async (
 	return new Set(files);
 };
 
+const ignoredDirectories = new Set(['node_modules', '.git']);
+
+/**
+ * All files that exist on disk, as posix relative paths (matching the format
+ * returned by npm-packlist). Used to tell files that are excluded from the
+ * published package apart from files that simply don't exist yet (e.g. build
+ * artifacts that haven't been generated).
+ */
+export const getLocalFiles = async (cwd: string) => {
+	const files = new Set<string>();
+
+	const walk = async (directory: string) => {
+		const entries = await readdir(directory, { withFileTypes: true });
+		await Promise.all(
+			entries.map(async (entry) => {
+				if (entry.isDirectory()) {
+					if (!ignoredDirectories.has(entry.name)) {
+						await walk(path.join(directory, entry.name));
+					}
+					return;
+				}
+
+				if (entry.isFile()) {
+					const relativePath = path.relative(cwd, path.join(directory, entry.name));
+					files.add(relativePath.split(path.sep).join('/'));
+				}
+			}),
+		);
+	};
+
+	await walk(cwd);
+	return files;
+};
+
 const wildcardMatchesAnyFile = (
 	pattern: string,
-	publishedFiles: Set<string>,
+	files: Set<string>,
 ) => {
 	const normalized = pattern.slice(2);
 	const prefix = normalized.slice(0, normalized.indexOf('*'));
 	const suffix = normalized.slice(normalized.indexOf('*') + 1);
 
-	return Array.from(publishedFiles).some(
+	return Array.from(files).some(
 		file => file.startsWith(prefix) && file.endsWith(suffix),
 	);
 };
@@ -33,26 +67,32 @@ const wildcardMatchesAnyFile = (
 export const pruneUnpublishedPaths = (
 	value: unknown,
 	publishedFiles: Set<string>,
-	cwd: string,
+	localFiles: Set<string>,
 ) => {
-	// Paths removed even though the file isn't on disk, likely an unbuilt
-	// artifact rather than a deliberately excluded source file.
+	// Paths removed even though nothing matches on disk, likely unbuilt
+	// artifacts rather than deliberately excluded source files.
 	const removedMissingFiles: string[] = [];
 
 	const pruneString = (node: string) => {
 		if (!node.startsWith('./')) {
 			return node;
 		}
+
 		if (node.includes('*')) {
-			return wildcardMatchesAnyFile(node, publishedFiles) ? node : undefined;
+			if (wildcardMatchesAnyFile(node, publishedFiles)) {
+				return node;
+			}
+			if (!wildcardMatchesAnyFile(node, localFiles)) {
+				removedMissingFiles.push(node);
+			}
+			return undefined;
 		}
 
 		const filePath = node.slice(2);
 		if (publishedFiles.has(filePath)) {
 			return node;
 		}
-
-		if (!existsSync(path.resolve(cwd, filePath))) {
+		if (!localFiles.has(filePath)) {
 			removedMissingFiles.push(node);
 		}
 		return undefined;

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'node:fs';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import packlist from 'npm-packlist';
 
@@ -17,109 +17,77 @@ export const getPublishedFiles = async (
 	return new Set(files);
 };
 
-const ignoredDirectories = new Set(['node_modules', '.git']);
-
-/**
- * All files that exist on disk, as posix relative paths (matching the format
- * returned by npm-packlist). Used to distinguish files that are excluded from
- * the published package from files that simply don't exist yet (e.g. build
- * artifacts that haven't been generated).
- */
-export const getLocalFiles = async (cwd: string) => {
-	const files = new Set<string>();
-
-	const walk = async (directory: string) => {
-		const entries = await fs.readdir(directory, { withFileTypes: true });
-		await Promise.all(
-			entries.map(async (entry) => {
-				if (entry.isDirectory()) {
-					if (!ignoredDirectories.has(entry.name)) {
-						await walk(path.join(directory, entry.name));
-					}
-					return;
-				}
-
-				if (entry.isFile()) {
-					const relativePath = path.relative(cwd, path.join(directory, entry.name));
-					files.add(relativePath.split(path.sep).join('/'));
-				}
-			}),
-		);
-	};
-
-	await walk(cwd);
-	return files;
-};
-
 const wildcardMatchesAnyFile = (
 	pattern: string,
-	files: Set<string>,
+	publishedFiles: Set<string>,
 ) => {
 	const normalized = pattern.slice(2);
-	const starIndex = normalized.indexOf('*');
-	const prefix = normalized.slice(0, starIndex);
-	const suffix = normalized.slice(starIndex + 1);
+	const prefix = normalized.slice(0, normalized.indexOf('*'));
+	const suffix = normalized.slice(normalized.indexOf('*') + 1);
 
-	return Array.from(files).some(
+	return Array.from(publishedFiles).some(
 		file => file.startsWith(prefix) && file.endsWith(suffix),
 	);
-};
-
-/**
- * A relative path should be kept unless it points to a file that exists on disk
- * but is excluded from the published package (e.g. a source file referenced by a
- * dev-only condition). Paths whose targets don't exist on disk are kept, since
- * they may be build artifacts that haven't been generated yet.
- */
-const isPathPublishable = (
-	value: string,
-	publishedFiles: Set<string>,
-	localFiles: Set<string>,
-) => {
-	if (value.includes('*')) {
-		return (
-			wildcardMatchesAnyFile(value, publishedFiles)
-			|| !wildcardMatchesAnyFile(value, localFiles)
-		);
-	}
-
-	const filePath = value.slice(2);
-	return publishedFiles.has(filePath) || !localFiles.has(filePath);
 };
 
 export const pruneUnpublishedPaths = (
 	value: unknown,
 	publishedFiles: Set<string>,
-	localFiles: Set<string>,
-): unknown | undefined => {
-	if (value === null) {
-		return null;
-	}
+	cwd: string,
+) => {
+	// Paths removed even though the file isn't on disk, likely an unbuilt
+	// artifact rather than a deliberately excluded source file.
+	const removedMissingFiles: string[] = [];
 
-	if (typeof value === 'string') {
-		if (!value.startsWith('./')) {
-			return value;
+	const pruneString = (node: string) => {
+		if (!node.startsWith('./')) {
+			return node;
 		}
-		return isPathPublishable(value, publishedFiles, localFiles) ? value : undefined;
-	}
+		if (node.includes('*')) {
+			return wildcardMatchesAnyFile(node, publishedFiles) ? node : undefined;
+		}
 
-	if (Array.isArray(value)) {
-		const kept = value
-			.map(item => pruneUnpublishedPaths(item, publishedFiles, localFiles))
-			.filter(item => item !== undefined);
-		return kept.length > 0 ? kept : undefined;
-	}
+		const filePath = node.slice(2);
+		if (publishedFiles.has(filePath)) {
+			return node;
+		}
 
-	if (typeof value === 'object') {
-		const kept: Record<string, unknown> = {};
-		for (const [key, child] of Object.entries(value)) {
-			const pruned = pruneUnpublishedPaths(child, publishedFiles, localFiles);
-			if (pruned !== undefined) {
-				kept[key] = pruned;
+		if (!existsSync(path.resolve(cwd, filePath))) {
+			removedMissingFiles.push(node);
+		}
+		return undefined;
+	};
+
+	const prune = (node: unknown): unknown | undefined => {
+		if (node === null) {
+			return null;
+		}
+
+		if (typeof node === 'string') {
+			return pruneString(node);
+		}
+
+		if (Array.isArray(node)) {
+			const kept = node.map(prune).filter(item => item !== undefined);
+			return kept.length > 0 ? kept : undefined;
+		}
+
+		if (typeof node === 'object') {
+			const kept: Record<string, unknown> = {};
+			for (const [key, child] of Object.entries(node)) {
+				const pruned = prune(child);
+				if (pruned !== undefined) {
+					kept[key] = pruned;
+				}
 			}
+			return Object.keys(kept).length > 0 ? kept : undefined;
 		}
-		return Object.keys(kept).length > 0 ? kept : undefined;
-	}
 
-	return value;
+		return node;
+	};
+
+	return {
+		result: prune(value),
+		removedMissingFiles,
+	};
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -153,10 +153,46 @@ const listFilesUnder = async (
 	return files;
 };
 
+// A resolved path is within the package only if it's the root or under it.
+// Targets that escape (via `../`) are invalid per Node and never published.
+const isWithin = (root: string, resolved: string) => (
+	resolved === root || resolved.startsWith(root + path.sep)
+);
+
+const targetExistsOnDisk = async (
+	fs: FileSystem,
+	cwd: string,
+	target: string,
+	directoryCache: Map<string, string[]>,
+) => {
+	if (!target.includes('*')) {
+		const resolved = path.resolve(cwd, target);
+		return isWithin(cwd, resolved) && fileExists(fs, resolved);
+	}
+
+	const matcher = createPathMatcher(target);
+	// The literal prefix (before the first `*`) bounds the directory we scan,
+	// so we never read the whole tree.
+	const prefix = matcher.segments[0];
+	const lastSlash = prefix.lastIndexOf('/');
+	const scope = lastSlash === -1 ? '.' : prefix.slice(0, lastSlash);
+	const directory = path.resolve(cwd, scope);
+	if (!isWithin(cwd, directory)) {
+		return false;
+	}
+
+	let files = directoryCache.get(directory);
+	if (!files) {
+		files = await listFilesUnder(fs, cwd, directory);
+		directoryCache.set(directory, files);
+	}
+	return files.some(file => pathMatches(matcher, file));
+};
+
 /**
  * Of the dropped specifiers, finds the ones whose target file doesn't exist on
  * disk (likely an unbuilt artifact, rather than a deliberately excluded source
- * file). Only touches the filesystem within the referenced scopes.
+ * file). Only touches the filesystem within the package root's referenced scopes.
  */
 const findMissingFiles = async (
 	fs: FileSystem,
@@ -167,28 +203,7 @@ const findMissingFiles = async (
 	const directoryCache = new Map<string, string[]>();
 
 	for (const specifier of prunedSpecifiers) {
-		const target = specifier.slice(2);
-
-		let exists: boolean;
-		if (target.includes('*')) {
-			const matcher = createPathMatcher(target);
-			// The literal prefix (before the first `*`) bounds the directory we
-			// need to scan, so we never read the whole tree.
-			const prefix = matcher.segments[0];
-			const lastSlash = prefix.lastIndexOf('/');
-			const scope = lastSlash === -1 ? '.' : prefix.slice(0, lastSlash);
-			const directory = path.resolve(cwd, scope);
-
-			let files = directoryCache.get(directory);
-			if (!files) {
-				files = await listFilesUnder(fs, cwd, directory);
-				directoryCache.set(directory, files);
-			}
-			exists = files.some(file => pathMatches(matcher, file));
-		} else {
-			exists = await fileExists(fs, path.resolve(cwd, target));
-		}
-
+		const exists = await targetExistsOnDisk(fs, cwd, specifier.slice(2), directoryCache);
 		if (!exists) {
 			missingFiles.add(specifier);
 		}

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -43,48 +43,97 @@ const specifierMatches = (
 	);
 };
 
+type RemovedEntry = {
+	// Consumer-facing specifier the target was reached through, e.g. "pkg/sub".
+	subpath: string;
+
+	// Condition chain leading to the target, e.g. ["node", "require"].
+	conditions: string[];
+
+	// The `./`-relative target that was removed.
+	target: string;
+};
+
+// The consumer-facing specifier for a subpath key. Exports resolve through the
+// package name (`.` -> name, `./sub` -> name/sub); imports keys are used as-is.
+const resolveSubpath = (
+	subpathKey: string,
+	packageName: string | undefined,
+	isExports: boolean,
+) => {
+	if (!isExports || !packageName) {
+		return subpathKey;
+	}
+	return subpathKey === '.' ? packageName : packageName + subpathKey.slice(1);
+};
+
+// Whether the top-level value maps subpaths (vs. being conditions sugar for
+// "."). Imports are always a subpath map; exports are when keys start with ".".
+const isSubpathMap = (
+	value: Record<string, unknown>,
+	isExports: boolean,
+) => {
+	const keys = Object.keys(value);
+	return keys.length > 0 && (!isExports || keys[0].startsWith('.'));
+};
+
 /**
- * Recursively prunes `exports`/`imports` values, dropping `./`-relative
- * specifiers that won't be published. Returns the pruned value (or `undefined`
- * when nothing is left) along with the specifiers that were dropped.
+ * Prunes an `exports`/`imports` field, dropping `./`-relative targets that
+ * won't be published. Returns the pruned value (or `undefined` when nothing is
+ * left) and a record of each dropped target with the subpath and conditions it
+ * was reached through.
  */
-const prunePaths = (
+const pruneField = (
 	value: unknown,
 	publishedFiles: Set<string>,
+	packageName: string | undefined,
+	isExports: boolean,
 ) => {
-	const prunedSpecifiers: string[] = [];
+	const removed: RemovedEntry[] = [];
 
-	const pruneSpecifier = (specifier: string) => {
+	const pruneLeaf = (specifier: string, subpath: string, conditions: string[]) => {
 		if (!specifier.startsWith('./')) {
 			return specifier;
 		}
 		if (specifierMatches(specifier, publishedFiles)) {
 			return specifier;
 		}
-		prunedSpecifiers.push(specifier);
+		removed.push({
+			subpath,
+			conditions,
+			target: specifier,
+		});
 		return undefined;
 	};
 
-	const prune = (node: unknown): unknown | undefined => {
+	// Prunes a target (string | conditions object | fallback array | null)
+	// reached via `subpath` under `conditions`.
+	const pruneTarget = (
+		node: unknown,
+		subpath: string,
+		conditions: string[],
+	): unknown | undefined => {
 		if (node === null) {
 			return null;
 		}
 
 		if (typeof node === 'string') {
-			return pruneSpecifier(node);
+			return pruneLeaf(node, subpath, conditions);
 		}
 
 		if (Array.isArray(node)) {
-			const kept = node.map(prune).filter(item => item !== undefined);
+			const kept = node
+				.map(item => pruneTarget(item, subpath, conditions))
+				.filter(item => item !== undefined);
 			return kept.length > 0 ? kept : undefined;
 		}
 
 		if (typeof node === 'object') {
 			const kept: Record<string, unknown> = {};
-			for (const [key, child] of Object.entries(node)) {
-				const pruned = prune(child);
+			for (const [condition, child] of Object.entries(node)) {
+				const pruned = pruneTarget(child, subpath, [...conditions, condition]);
 				if (pruned !== undefined) {
-					kept[key] = pruned;
+					kept[condition] = pruned;
 				}
 			}
 			return Object.keys(kept).length > 0 ? kept : undefined;
@@ -93,9 +142,30 @@ const prunePaths = (
 		return node;
 	};
 
+	if (
+		typeof value === 'object'
+		&& value !== null
+		&& !Array.isArray(value)
+		&& isSubpathMap(value as Record<string, unknown>, isExports)
+	) {
+		const kept: Record<string, unknown> = {};
+		for (const [subpathKey, target] of Object.entries(value)) {
+			const subpath = resolveSubpath(subpathKey, packageName, isExports);
+			const pruned = pruneTarget(target, subpath, []);
+			if (pruned !== undefined) {
+				kept[subpathKey] = pruned;
+			}
+		}
+		return {
+			result: Object.keys(kept).length > 0 ? kept : undefined,
+			removed,
+		};
+	}
+
+	// Sugar: the whole value is the target for the "." subpath.
 	return {
-		result: prune(value),
-		prunedSpecifiers,
+		result: pruneTarget(value, resolveSubpath('.', packageName, isExports), []),
+		removed,
 	};
 };
 
@@ -191,34 +261,42 @@ const targetExistsOnDisk = async (
 };
 
 /**
- * Of the dropped specifiers, finds the ones whose target file doesn't exist on
- * disk (likely an unbuilt artifact, rather than a deliberately excluded source
- * file). Only touches the filesystem within the package root's referenced scopes.
+ * Of the dropped entries, finds the ones whose target doesn't exist on disk
+ * (likely an unbuilt artifact, rather than a deliberately excluded source
+ * file). Only touches the filesystem within the package root's referenced
+ * scopes, and checks each distinct target once.
  */
-const findMissingFiles = async (
+const findMissingEntries = async (
 	fs: FileSystem,
 	cwd: string,
-	prunedSpecifiers: string[],
+	removed: RemovedEntry[],
 ) => {
-	const missingFiles = new Set<string>();
+	const missing: RemovedEntry[] = [];
 	const directoryCache = new Map<string, string[]>();
+	const existenceCache = new Map<string, boolean>();
 
-	for (const specifier of prunedSpecifiers) {
-		const exists = await targetExistsOnDisk(fs, cwd, specifier.slice(2), directoryCache);
+	for (const entry of removed) {
+		let exists = existenceCache.get(entry.target);
+		if (exists === undefined) {
+			exists = await targetExistsOnDisk(fs, cwd, entry.target.slice(2), directoryCache);
+			existenceCache.set(entry.target, exists);
+		}
 		if (!exists) {
-			missingFiles.add(specifier);
+			missing.push(entry);
 		}
 	}
 
-	return missingFiles;
+	return missing;
 };
 
-const warnMissingFiles = (missingFiles: Set<string>) => {
-	console.warn(yellow(
-		'Removed exports/imports entries pointing to files that '
-		+ `don't exist: ${Array.from(missingFiles).join(', ')}\n`
-		+ 'If these are build outputs, build the package first.',
-	));
+const warnRemovedEntry = ({ subpath, conditions, target }: RemovedEntry) => {
+	const conditionsText = conditions.length > 0
+		? ` with conditions ${conditions.join(' + ')}`
+		: '';
+	console.warn(
+		`${yellow('⚠️ Warning:')} ${subpath}${conditionsText} `
+		+ `was removed because ${target} doesn't exist`,
+	);
 };
 
 /**
@@ -238,13 +316,17 @@ export const pruneUnpublishedPaths = async (
 	}
 
 	const publishedFiles = await getPublishedFiles(cwd, packageJson);
+	const packageName = typeof packageJson.name === 'string' ? packageJson.name : undefined;
 
-	const prunedSpecifiers = new Set<string>();
+	const removed: RemovedEntry[] = [];
 	for (const field of fields) {
-		const { result, prunedSpecifiers: dropped } = prunePaths(packageJson[field], publishedFiles);
-		for (const specifier of dropped) {
-			prunedSpecifiers.add(specifier);
-		}
+		const { result, removed: fieldRemoved } = pruneField(
+			packageJson[field],
+			publishedFiles,
+			packageName,
+			field === 'exports',
+		);
+		removed.push(...fieldRemoved);
 
 		if (result === undefined) {
 			log(`Removing property "${field}" (no published files referenced)`);
@@ -254,12 +336,12 @@ export const pruneUnpublishedPaths = async (
 		}
 	}
 
-	if (prunedSpecifiers.size === 0) {
+	if (removed.length === 0) {
 		return;
 	}
 
-	const missingFiles = await findMissingFiles(fs, cwd, Array.from(prunedSpecifiers));
-	if (missingFiles.size > 0) {
-		warnMissingFiles(missingFiles);
+	const missing = await findMissingEntries(fs, cwd, removed);
+	for (const entry of missing) {
+		warnRemovedEntry(entry);
 	}
 };

--- a/src/prune-unpublished-paths.ts
+++ b/src/prune-unpublished-paths.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import packlist from 'npm-packlist';
 
 const edgesOut = new Map();
@@ -15,22 +17,80 @@ export const getPublishedFiles = async (
 	return new Set(files);
 };
 
+const ignoredDirectories = new Set(['node_modules', '.git']);
+
+/**
+ * All files that exist on disk, as posix relative paths (matching the format
+ * returned by npm-packlist). Used to distinguish files that are excluded from
+ * the published package from files that simply don't exist yet (e.g. build
+ * artifacts that haven't been generated).
+ */
+export const getLocalFiles = async (cwd: string) => {
+	const files = new Set<string>();
+
+	const walk = async (directory: string) => {
+		const entries = await fs.readdir(directory, { withFileTypes: true });
+		await Promise.all(
+			entries.map(async (entry) => {
+				if (entry.isDirectory()) {
+					if (!ignoredDirectories.has(entry.name)) {
+						await walk(path.join(directory, entry.name));
+					}
+					return;
+				}
+
+				if (entry.isFile()) {
+					const relativePath = path.relative(cwd, path.join(directory, entry.name));
+					files.add(relativePath.split(path.sep).join('/'));
+				}
+			}),
+		);
+	};
+
+	await walk(cwd);
+	return files;
+};
+
 const wildcardMatchesAnyFile = (
 	pattern: string,
-	publishedFiles: Set<string>,
+	files: Set<string>,
 ) => {
 	const normalized = pattern.slice(2);
-	const prefix = normalized.slice(0, normalized.indexOf('*'));
-	const suffix = normalized.slice(normalized.indexOf('*') + 1);
+	const starIndex = normalized.indexOf('*');
+	const prefix = normalized.slice(0, starIndex);
+	const suffix = normalized.slice(starIndex + 1);
 
-	return Array.from(publishedFiles).some(
+	return Array.from(files).some(
 		file => file.startsWith(prefix) && file.endsWith(suffix),
 	);
+};
+
+/**
+ * A relative path should be kept unless it points to a file that exists on disk
+ * but is excluded from the published package (e.g. a source file referenced by a
+ * dev-only condition). Paths whose targets don't exist on disk are kept, since
+ * they may be build artifacts that haven't been generated yet.
+ */
+const isPathPublishable = (
+	value: string,
+	publishedFiles: Set<string>,
+	localFiles: Set<string>,
+) => {
+	if (value.includes('*')) {
+		return (
+			wildcardMatchesAnyFile(value, publishedFiles)
+			|| !wildcardMatchesAnyFile(value, localFiles)
+		);
+	}
+
+	const filePath = value.slice(2);
+	return publishedFiles.has(filePath) || !localFiles.has(filePath);
 };
 
 export const pruneUnpublishedPaths = (
 	value: unknown,
 	publishedFiles: Set<string>,
+	localFiles: Set<string>,
 ): unknown | undefined => {
 	if (value === null) {
 		return null;
@@ -40,15 +100,12 @@ export const pruneUnpublishedPaths = (
 		if (!value.startsWith('./')) {
 			return value;
 		}
-		if (value.includes('*')) {
-			return wildcardMatchesAnyFile(value, publishedFiles) ? value : undefined;
-		}
-		return publishedFiles.has(value.slice(2)) ? value : undefined;
+		return isPathPublishable(value, publishedFiles, localFiles) ? value : undefined;
 	}
 
 	if (Array.isArray(value)) {
 		const kept = value
-			.map(item => pruneUnpublishedPaths(item, publishedFiles))
+			.map(item => pruneUnpublishedPaths(item, publishedFiles, localFiles))
 			.filter(item => item !== undefined);
 		return kept.length > 0 ? kept : undefined;
 	}
@@ -56,7 +113,7 @@ export const pruneUnpublishedPaths = (
 	if (typeof value === 'object') {
 		const kept: Record<string, unknown> = {};
 		for (const [key, child] of Object.entries(value)) {
-			const pruned = pruneUnpublishedPaths(child, publishedFiles);
+			const pruned = pruneUnpublishedPaths(child, publishedFiles, localFiles);
 			if (pruned !== undefined) {
 				kept[key] = pruned;
 			}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -531,17 +531,49 @@ describe('prune unpublished paths', () => {
 });
 
 describe('path matcher', () => {
-	test('single star captures the wildcard value', () => {
-		const matcher = createPathMatcher('dist/*.js');
-		expect(pathMatches(matcher, 'dist/index.js')).toBe('index');
-		expect(pathMatches(matcher, 'dist/nested/file.js')).toBe('nested/file');
-		expect(pathMatches(matcher, 'dist/index.mjs')).toBeUndefined();
-		expect(pathMatches(matcher, 'src/index.js')).toBeUndefined();
+	// Whether a file path is a possible expansion of a `*` target pattern,
+	// per Node's exports/imports resolution: every `*` is replaced by the same
+	// captured value (which may contain `/`).
+	// https://nodejs.org/api/packages.html#subpath-patterns
+	const matches = (
+		pattern: string,
+		filePath: string,
+	) => pathMatches(createPathMatcher(pattern), filePath);
+
+	test('single star matches by prefix and suffix', () => {
+		expect(matches('dist/*.js', 'dist/index.js')).toBe(true);
+		expect(matches('dist/*.js', 'dist/index.mjs')).toBe(false);
+		expect(matches('dist/*.js', 'src/index.js')).toBe(false);
 	});
 
-	test('multiple stars must capture the same value', () => {
-		const matcher = createPathMatcher('locale/*/*.js');
-		expect(pathMatches(matcher, 'locale/en/en.js')).toBe('en');
-		expect(pathMatches(matcher, 'locale/en/fr.js')).toBeUndefined();
+	test('star spans path separators', () => {
+		// Node: "All instances of * ... replaced ... including if it contains
+		// any / separators."
+		expect(matches('features/*', 'features/x')).toBe(true);
+		expect(matches('features/*', 'features/y/y')).toBe(true);
+		expect(matches('dist/*.js', 'dist/nested/file.js')).toBe(true);
+	});
+
+	test('star may capture an empty value', () => {
+		expect(matches('dist/*.js', 'dist/.js')).toBe(true);
+	});
+
+	test('does not match when prefix and suffix would overlap', () => {
+		// `aaa*aaa` needs at least 6 chars; the captured value can't be negative.
+		expect(matches('aaa*aaa', 'aaaXaaa')).toBe(true);
+		expect(matches('aaa*aaa', 'aaaaa')).toBe(false);
+	});
+
+	test('repeated stars must resolve to the same value', () => {
+		expect(matches('dist/*-*.js', 'dist/a-a.js')).toBe(true);
+		expect(matches('dist/*-*.js', 'dist/a-b.js')).toBe(false);
+		expect(matches('locale/*/*.js', 'locale/en/en.js')).toBe(true);
+		expect(matches('locale/*/*.js', 'locale/en/fr.js')).toBe(false);
+	});
+
+	test('repeated stars match when the captured value contains the separator', () => {
+		// `*-*` with capture `foo-bar` expands to `foo-bar-foo-bar`.
+		expect(matches('dist/*-*.js', 'dist/foo-bar-foo-bar.js')).toBe(true);
+		expect(matches('dist/*-*.js', 'dist/foo-bar.js')).toBe(false);
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -354,7 +354,7 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('wildcard patterns — pruned when no matching files exist', async () => {
+	test('wildcard patterns — pruned and warns when no matching files exist', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
 			'package.json': JSON.stringify({
@@ -368,12 +368,37 @@ describe('prune unpublished paths', () => {
 			}),
 		});
 
-		await cleanPkgJson(fixture.path);
+		const { stderr } = await cleanPkgJson(fixture.path);
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({
 			'.': './dist/index.js',
 		});
+		expect(stderr).toContain('./src/utils/*.ts');
+	});
+
+	test('wildcard patterns — pruned silently when matching files exist but are excluded', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'src/utils/format.ts': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./utils/*': './src/utils/*.ts',
+				},
+			}),
+		});
+
+		const { stderr } = await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': './dist/index.js',
+		});
+		expect(stderr).not.toContain("don't exist");
 	});
 
 	test('--published-only=false disables path pruning', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -9,6 +9,9 @@ import { createPathMatcher, pathMatches } from '../src/path-matcher.ts';
 
 const cleanPkgJsonPath = path.resolve('./src/index.ts');
 
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (value: string) => value.replaceAll(/\u001B\[[0-9;]*m/g, '');
+
 const cleanPkgJson = (
 	cwd: string,
 	flags: string[] = [],
@@ -512,10 +515,11 @@ describe('prune unpublished paths', () => {
 		});
 
 		const { stderr } = await cleanPkgJson(fixture.path);
+		const output = stripAnsi(stderr);
 
-		expect(stderr).toContain('my-pkg/sub');
-		expect(stderr).toContain('node + require');
-		expect(stderr).toContain('was removed because ./dist/sub.cjs');
+		expect(output).toContain('my-pkg/sub');
+		expect(output).toContain('node + require');
+		expect(output).toContain('was removed because ./dist/sub.cjs');
 	});
 
 	test('warning omits conditions for a direct subpath target', async () => {
@@ -533,9 +537,10 @@ describe('prune unpublished paths', () => {
 		});
 
 		const { stderr } = await cleanPkgJson(fixture.path);
+		const output = stripAnsi(stderr);
 
-		expect(stderr).toContain('my-pkg/missing was removed because ./dist/missing.js');
-		expect(stderr).not.toContain('with conditions');
+		expect(output).toContain('my-pkg/missing was removed because ./dist/missing.js');
+		expect(output).not.toContain('with conditions');
 	});
 
 	test('only reads the referenced directory for wildcards, not the whole tree', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -155,6 +155,7 @@ describe('prune unpublished paths', () => {
 	test('prunes import entry pointing to unpublished file', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
+			'src/utils.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -195,6 +196,7 @@ describe('prune unpublished paths', () => {
 	test('conditional import — prunes only unpublished branches', async () => {
 		await using fixture = await createFixture({
 			'dist/config.js': '',
+			'src/config.dev.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -221,6 +223,8 @@ describe('prune unpublished paths', () => {
 	test('conditional import — removes entry when all branches unpublished', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
+			'src/internal.dev.ts': '',
+			'src/internal.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -243,6 +247,7 @@ describe('prune unpublished paths', () => {
 	test('exports — prunes unpublished branches', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
+			'src/index.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -269,6 +274,7 @@ describe('prune unpublished paths', () => {
 	test('bare string export — prunes if unpublished', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
+			'src/index.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -309,6 +315,7 @@ describe('prune unpublished paths', () => {
 	test('fallback arrays — prunes unpublished entries', async () => {
 		await using fixture = await createFixture({
 			'dist/index.mjs': '',
+			'src/index.js': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -354,9 +361,10 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('wildcard patterns — pruned when no matching files exist', async () => {
+	test('wildcard patterns — pruned when matching files exist but are excluded', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
+			'src/utils/format.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -417,6 +425,64 @@ describe('prune unpublished paths', () => {
 		expect(result.imports).toStrictEqual({
 			'#dep': 'lodash',
 			'#local': './dist/index.js',
+		});
+	});
+
+	test('preserves entries whose target files do not exist yet (pre-build)', async () => {
+		await using fixture = await createFixture({
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				exports: {
+					'.': {
+						require: './dist/index.cjs',
+						default: './dist/index.mjs',
+					},
+					'./constant': {
+						require: './constant.js',
+						default: './esm/constant.js',
+					},
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'.': {
+				require: './dist/index.cjs',
+				default: './dist/index.mjs',
+			},
+			'./constant': {
+				require: './constant.js',
+				default: './esm/constant.js',
+			},
+		});
+	});
+
+	test('preserves wildcard entries whose target files do not exist yet (pre-build)', async () => {
+		await using fixture = await createFixture({
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				exports: {
+					'./locale/*': {
+						require: './locale/*.js',
+						default: './esm/locale/*.js',
+					},
+				},
+			}),
+		});
+
+		await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({
+			'./locale/*': {
+				require: './locale/*.js',
+				default: './esm/locale/*.js',
+			},
 		});
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -529,6 +529,44 @@ describe('prune unpublished paths', () => {
 		expect(packageJson.exports).toStrictEqual({ '.': './dist/index.js' });
 	});
 
+	test('never touches the filesystem outside the package root', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./escape': './../outside.js',
+					'./glob': './../*.js',
+				},
+			}),
+		});
+
+		const accessed: string[] = [];
+		const record = (target: string) => accessed.push(target.split(path.sep).join('/'));
+		const spyFs = {
+			stat: ((target: string) => {
+				record(target);
+				return nodeFs.stat(target);
+			}) as typeof nodeFs.stat,
+			readdir: ((target: string, options: unknown) => {
+				record(target);
+				return nodeFs.readdir(target as string, options as never);
+			}) as typeof nodeFs.readdir,
+		};
+
+		const packageJson = await fixture.readJson<Record<string, unknown>>('package.json');
+		await pruneUnpublishedPaths(fixture.path, packageJson, () => {}, spyFs);
+
+		const root = fixture.path.split(path.sep).join('/');
+		const allWithinRoot = accessed.every(
+			target => target === root || target.startsWith(`${root}/`),
+		);
+		expect(allWithinRoot).toBe(true);
+	});
+
 	test('wildcard existence scan ignores node_modules', async () => {
 		// A root-scoped wildcard scans the package root; node_modules files must
 		// not count as a match (Node forbids node_modules in export targets).
@@ -578,8 +616,10 @@ describe('path matcher', () => {
 		expect(matches('dist/*.js', 'dist/nested/file.js')).toBe(true);
 	});
 
-	test('star may capture an empty value', () => {
-		expect(matches('dist/*.js', 'dist/.js')).toBe(true);
+	test('star requires a non-empty capture', () => {
+		// Node's key-side `*` must capture at least one character.
+		expect(matches('dist/*.js', 'dist/x.js')).toBe(true);
+		expect(matches('dist/*.js', 'dist/.js')).toBe(false);
 	});
 
 	test('does not match when prefix and suffix would overlap', () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -157,7 +157,19 @@ describe('clean-pkg-json', () => {
 	test('error on missing package.json', async () => {
 		await using fixture = await createFixture({});
 
-		await expect(cleanPkgJson(fixture.path)).rejects.toThrow();
+		const result = await cleanPkgJson(fixture.path).catch(error => error);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain('Error: ./package.json does not exist');
+	});
+
+	test('error on malformed package.json', async () => {
+		await using fixture = await createFixture({
+			'package.json': '{ "name": "x", bad }',
+		});
+
+		const result = await cleanPkgJson(fixture.path).catch(error => error);
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain('Error: Failed to parse ./package.json');
 	});
 });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,11 @@
 import path from 'path';
+import { promises as nodeFs } from 'node:fs';
 import { describe, test, expect } from 'manten';
 import spawn from 'nano-spawn';
 import { createFixture } from 'fs-fixture';
 import type { PackageJson } from 'type-fest';
+import { pruneUnpublishedPaths } from '../src/prune-unpublished-paths.ts';
+import { createPathMatcher, pathMatches } from '../src/path-matcher.ts';
 
 const cleanPkgJsonPath = path.resolve('./src/index.ts');
 
@@ -488,5 +491,57 @@ describe('prune unpublished paths', () => {
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({ '.': { default: './dist/index.js' } });
 		expect(stderr).not.toContain("don't exist");
+	});
+
+	test('only reads the referenced directory for wildcards, not the whole tree', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'unrelated/deep/file.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./utils/*': './src/utils/*.ts',
+				},
+			}),
+		});
+
+		const readDirectories: string[] = [];
+		const spyFs = {
+			stat: nodeFs.stat,
+			readdir: ((directory: string, options: unknown) => {
+				readDirectories.push(directory.split(path.sep).join('/'));
+				return nodeFs.readdir(directory as string, options as never);
+			}) as typeof nodeFs.readdir,
+		};
+
+		const packageJson = await fixture.readJson<Record<string, unknown>>('package.json');
+		await pruneUnpublishedPaths(fixture.path, packageJson, () => {}, spyFs);
+
+		// The only pruned specifier is the wildcard './src/utils/*.ts',
+		// so we must scan its directory (src/utils) and nothing else.
+		const root = fixture.path.split(path.sep).join('/');
+		expect(readDirectories).not.toContain(root);
+		expect(readDirectories.some(directory => directory.endsWith('/unrelated'))).toBe(false);
+		expect(readDirectories.some(directory => directory.endsWith('/src/utils'))).toBe(true);
+		expect(packageJson.exports).toStrictEqual({ '.': './dist/index.js' });
+	});
+});
+
+describe('path matcher', () => {
+	test('single star captures the wildcard value', () => {
+		const matcher = createPathMatcher('dist/*.js');
+		expect(pathMatches(matcher, 'dist/index.js')).toBe('index');
+		expect(pathMatches(matcher, 'dist/nested/file.js')).toBe('nested/file');
+		expect(pathMatches(matcher, 'dist/index.mjs')).toBeUndefined();
+		expect(pathMatches(matcher, 'src/index.js')).toBeUndefined();
+	});
+
+	test('multiple stars must capture the same value', () => {
+		const matcher = createPathMatcher('locale/*/*.js');
+		expect(pathMatches(matcher, 'locale/en/en.js')).toBe('en');
+		expect(pathMatches(matcher, 'locale/en/fr.js')).toBeUndefined();
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -9,16 +9,20 @@ import { createPathMatcher, pathMatches } from '../src/path-matcher.ts';
 
 const cleanPkgJsonPath = path.resolve('./src/index.ts');
 
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (value: string) => value.replaceAll(/\u001B\[[0-9;]*m/g, '');
-
 const cleanPkgJson = (
 	cwd: string,
 	flags: string[] = [],
 ) => spawn(
 	process.execPath,
 	[cleanPkgJsonPath, ...flags],
-	{ cwd },
+	// NO_COLOR keeps warning output plain so assertions match the message text.
+	{
+		cwd,
+		env: {
+			...process.env,
+			NO_COLOR: '1',
+		},
+	},
 );
 
 const fixturePackageJson = {
@@ -515,11 +519,10 @@ describe('prune unpublished paths', () => {
 		});
 
 		const { stderr } = await cleanPkgJson(fixture.path);
-		const output = stripAnsi(stderr);
 
-		expect(output).toContain('my-pkg/sub');
-		expect(output).toContain('node + require');
-		expect(output).toContain('was removed because ./dist/sub.cjs');
+		expect(stderr).toContain('my-pkg/sub');
+		expect(stderr).toContain('node + require');
+		expect(stderr).toContain('was removed because ./dist/sub.cjs');
 	});
 
 	test('warning omits conditions for a direct subpath target', async () => {
@@ -537,10 +540,9 @@ describe('prune unpublished paths', () => {
 		});
 
 		const { stderr } = await cleanPkgJson(fixture.path);
-		const output = stripAnsi(stderr);
 
-		expect(output).toContain('my-pkg/missing was removed because ./dist/missing.js');
-		expect(output).not.toContain('with conditions');
+		expect(stderr).toContain('my-pkg/missing was removed because ./dist/missing.js');
+		expect(stderr).not.toContain('with conditions');
 	});
 
 	test('only reads the referenced directory for wildcards, not the whole tree', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -528,6 +528,30 @@ describe('prune unpublished paths', () => {
 		expect(readDirectories.some(directory => directory.endsWith('/src/utils'))).toBe(true);
 		expect(packageJson.exports).toStrictEqual({ '.': './dist/index.js' });
 	});
+
+	test('wildcard existence scan ignores node_modules', async () => {
+		// A root-scoped wildcard scans the package root; node_modules files must
+		// not count as a match (Node forbids node_modules in export targets).
+		await using fixture = await createFixture({
+			'dist/index.cjs': '',
+			'node_modules/dep/foo.js': '',
+			'package.json': JSON.stringify({
+				name: 'test-package',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.cjs',
+					'./*': './*.js',
+				},
+			}),
+		});
+
+		const { stderr } = await cleanPkgJson(fixture.path);
+
+		const result = await fixture.readJson<PackageJson>('package.json');
+		expect(result.exports).toStrictEqual({ '.': './dist/index.cjs' });
+		expect(stderr).toContain('./*.js');
+	});
 });
 
 describe('path matcher', () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -159,7 +159,7 @@ describe('clean-pkg-json', () => {
 
 		const result = await cleanPkgJson(fixture.path).catch(error => error);
 		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain('Error: ./package.json does not exist');
+		expect(result.stderr.trim()).toBe('Error: ./package.json does not exist');
 	});
 
 	test('error on malformed package.json', async () => {
@@ -169,7 +169,8 @@ describe('clean-pkg-json', () => {
 
 		const result = await cleanPkgJson(fixture.path).catch(error => error);
 		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toContain('Error: Failed to parse ./package.json');
+		// The trailing JSON parse reason is provided by Node and varies by version.
+		expect(result.stderr).toContain('Error: Failed to parse ./package.json: ');
 	});
 });
 
@@ -396,7 +397,9 @@ describe('prune unpublished paths', () => {
 		expect(result.exports).toStrictEqual({
 			'.': './dist/index.js',
 		});
-		expect(stderr).toContain('./src/utils/*.ts');
+		expect(stderr.trim()).toBe(
+			"Warning: test-package/utils/* was removed because ./src/utils/*.ts doesn't exist",
+		);
 	});
 
 	test('wildcard patterns — pruned silently when matching files exist but are excluded', async () => {
@@ -420,7 +423,7 @@ describe('prune unpublished paths', () => {
 		expect(result.exports).toStrictEqual({
 			'.': './dist/index.js',
 		});
-		expect(stderr).not.toContain('Warning');
+		expect(stderr).toBe('');
 	});
 
 	test('--published-only=false disables path pruning', async () => {
@@ -485,7 +488,9 @@ describe('prune unpublished paths', () => {
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({ '.': './dist/index.js' });
-		expect(stderr).toContain('./not-built.js');
+		expect(stderr.trim()).toBe(
+			"Warning: test-package/sub was removed because ./not-built.js doesn't exist",
+		);
 	});
 
 	test('does not warn when removing an excluded file that exists on disk', async () => {
@@ -509,7 +514,7 @@ describe('prune unpublished paths', () => {
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({ '.': { default: './dist/index.js' } });
-		expect(stderr).not.toContain('Warning');
+		expect(stderr).toBe('');
 	});
 
 	test('warning names the subpath, conditions, and missing target', async () => {
@@ -532,9 +537,10 @@ describe('prune unpublished paths', () => {
 
 		const { stderr } = await cleanPkgJson(fixture.path);
 
-		expect(stderr).toContain('my-pkg/sub');
-		expect(stderr).toContain('node + require');
-		expect(stderr).toContain('was removed because ./dist/sub.cjs');
+		expect(stderr.trim()).toBe(
+			'Warning: my-pkg/sub with conditions node + require '
+			+ "was removed because ./dist/sub.cjs doesn't exist",
+		);
 	});
 
 	test('warning omits conditions for a direct subpath target', async () => {
@@ -553,8 +559,9 @@ describe('prune unpublished paths', () => {
 
 		const { stderr } = await cleanPkgJson(fixture.path);
 
-		expect(stderr).toContain('my-pkg/missing was removed because ./dist/missing.js');
-		expect(stderr).not.toContain('with conditions');
+		expect(stderr.trim()).toBe(
+			"Warning: my-pkg/missing was removed because ./dist/missing.js doesn't exist",
+		);
 	});
 
 	test('only reads the referenced directory for wildcards, not the whole tree', async () => {
@@ -652,7 +659,9 @@ describe('prune unpublished paths', () => {
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({ '.': './dist/index.cjs' });
-		expect(stderr).toContain('./*.js');
+		expect(stderr.trim()).toBe(
+			"Warning: test-package/* was removed because ./*.js doesn't exist",
+		);
 	});
 });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -401,7 +401,7 @@ describe('prune unpublished paths', () => {
 		expect(result.exports).toStrictEqual({
 			'.': './dist/index.js',
 		});
-		expect(stderr).not.toContain("don't exist");
+		expect(stderr).not.toContain('Warning');
 	});
 
 	test('--published-only=false disables path pruning', async () => {
@@ -490,7 +490,52 @@ describe('prune unpublished paths', () => {
 
 		const result = await fixture.readJson<PackageJson>('package.json');
 		expect(result.exports).toStrictEqual({ '.': { default: './dist/index.js' } });
-		expect(stderr).not.toContain("don't exist");
+		expect(stderr).not.toContain('Warning');
+	});
+
+	test('warning names the subpath, conditions, and missing target', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'my-pkg',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./sub': {
+						node: {
+							require: './dist/sub.cjs',
+						},
+					},
+				},
+			}),
+		});
+
+		const { stderr } = await cleanPkgJson(fixture.path);
+
+		expect(stderr).toContain('my-pkg/sub');
+		expect(stderr).toContain('node + require');
+		expect(stderr).toContain('was removed because ./dist/sub.cjs');
+	});
+
+	test('warning omits conditions for a direct subpath target', async () => {
+		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'package.json': JSON.stringify({
+				name: 'my-pkg',
+				version: '1.0.0',
+				files: ['dist'],
+				exports: {
+					'.': './dist/index.js',
+					'./missing': './dist/missing.js',
+				},
+			}),
+		});
+
+		const { stderr } = await cleanPkgJson(fixture.path);
+
+		expect(stderr).toContain('my-pkg/missing was removed because ./dist/missing.js');
+		expect(stderr).not.toContain('with conditions');
 	});
 
 	test('only reads the referenced directory for wildcards, not the whole tree', async () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -155,7 +155,6 @@ describe('prune unpublished paths', () => {
 	test('prunes import entry pointing to unpublished file', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
-			'src/utils.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -196,7 +195,6 @@ describe('prune unpublished paths', () => {
 	test('conditional import — prunes only unpublished branches', async () => {
 		await using fixture = await createFixture({
 			'dist/config.js': '',
-			'src/config.dev.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -223,8 +221,6 @@ describe('prune unpublished paths', () => {
 	test('conditional import — removes entry when all branches unpublished', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
-			'src/internal.dev.ts': '',
-			'src/internal.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -247,7 +243,6 @@ describe('prune unpublished paths', () => {
 	test('exports — prunes unpublished branches', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
-			'src/index.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -274,7 +269,6 @@ describe('prune unpublished paths', () => {
 	test('bare string export — prunes if unpublished', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
-			'src/index.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -315,7 +309,6 @@ describe('prune unpublished paths', () => {
 	test('fallback arrays — prunes unpublished entries', async () => {
 		await using fixture = await createFixture({
 			'dist/index.mjs': '',
-			'src/index.js': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -361,10 +354,9 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('wildcard patterns — pruned when matching files exist but are excluded', async () => {
+	test('wildcard patterns — pruned when no matching files exist', async () => {
 		await using fixture = await createFixture({
 			'dist/index.js': '',
-			'src/utils/format.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
@@ -428,61 +420,48 @@ describe('prune unpublished paths', () => {
 		});
 	});
 
-	test('preserves entries whose target files do not exist yet (pre-build)', async () => {
+	test('warns when an entry is removed because its file does not exist', async () => {
 		await using fixture = await createFixture({
+			'dist/index.js': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
+				files: ['dist'],
 				exports: {
-					'.': {
-						require: './dist/index.cjs',
-						default: './dist/index.mjs',
-					},
-					'./constant': {
-						require: './constant.js',
-						default: './esm/constant.js',
-					},
+					'.': './dist/index.js',
+					'./sub': './not-built.js',
 				},
 			}),
 		});
 
-		await cleanPkgJson(fixture.path);
+		const { stderr } = await cleanPkgJson(fixture.path);
 
 		const result = await fixture.readJson<PackageJson>('package.json');
-		expect(result.exports).toStrictEqual({
-			'.': {
-				require: './dist/index.cjs',
-				default: './dist/index.mjs',
-			},
-			'./constant': {
-				require: './constant.js',
-				default: './esm/constant.js',
-			},
-		});
+		expect(result.exports).toStrictEqual({ '.': './dist/index.js' });
+		expect(stderr).toContain('./not-built.js');
 	});
 
-	test('preserves wildcard entries whose target files do not exist yet (pre-build)', async () => {
+	test('does not warn when removing an excluded file that exists on disk', async () => {
 		await using fixture = await createFixture({
+			'dist/index.js': '',
+			'src/index.ts': '',
 			'package.json': JSON.stringify({
 				name: 'test-package',
 				version: '1.0.0',
+				files: ['dist'],
 				exports: {
-					'./locale/*': {
-						require: './locale/*.js',
-						default: './esm/locale/*.js',
+					'.': {
+						source: './src/index.ts',
+						default: './dist/index.js',
 					},
 				},
 			}),
 		});
 
-		await cleanPkgJson(fixture.path);
+		const { stderr } = await cleanPkgJson(fixture.path);
 
 		const result = await fixture.readJson<PackageJson>('package.json');
-		expect(result.exports).toStrictEqual({
-			'./locale/*': {
-				require: './locale/*.js',
-				default: './esm/locale/*.js',
-			},
-		});
+		expect(result.exports).toStrictEqual({ '.': { default: './dist/index.js' } });
+		expect(stderr).not.toContain("don't exist");
 	});
 });


### PR DESCRIPTION
## Problem

The `--published-only` cleanup from #16 removes `exports`/`imports` entries that won't be in the published tarball, determined via `npm-packlist` (which only lists files that exist on disk). So running before a build (a standalone `npx clean-pkg-json`, or a preview) silently strips entries for not-yet-built artifacts. Reported in [#16 (comment)](https://github.com/privatenumber/clean-pkg-json/pull/16#issuecomment-4601154491).

## Changes

- **Warn instead of silently dropping.** When an entry is removed because its target file doesn't exist on disk, it's collected and surfaced in a single stderr warning with a "build first" hint. Entries removed because the file exists but is excluded from the package (the intended case, e.g. a `development` condition into `src/`) stay silent.
- **Minimal, scoped filesystem reads.** The prune decision is pure — it uses only npm-packlist's published set, no fs. On-disk existence is checked lazily, *only for dropped specifiers*, and *only within their referenced scopes*: a `stat` per concrete path, and a single `readdir` scoped to a wildcard's prefix directory (cached per dir). The normal prepack case (everything built + published, nothing dropped) does **zero** extra fs beyond npm-packlist.
- **Correct wildcard matching** via a dedicated `path-matcher` module (prefix/middle/suffix, multi-star capture validation).
- **`fs` dependency injection** so the scoped-read behavior is unit-testable.

## Notes

- Builds on #23 (Node ≥22); uses `fs.readdir({ recursive: true })`.
- `path-matcher` is ported from [pkg-entry-points](https://github.com/privatenumber/pkg-entry-points) with one fix: it validates the trailing multi-star segment (the reference doesn't). Single-star patterns — the only kind Node `exports` allows — behave identically; the fix only matters for the multi-star edge.

## Test plan

- Concrete: warns when the file is missing; silent when it exists but is excluded.
- Wildcard: warns when nothing matches on disk; silent when matches exist but are excluded.
- Scoped reads: a spy `fs` asserts only the referenced directory is read — never the tree root or unrelated directories.
- `path-matcher` unit tests (single + multi star).
- 25 tests pass; type-check + lint clean.
