### PR TITLE
feat: require Node.js >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
 	],
 	"type": "module",
 	"bin": "dist/index.mjs",
-	"engines": {
-		"node": ">=22"
-	},
 	"packageManager": "pnpm@9.15.4",
 	"scripts": {
 		"build": "pkgroll --target=node22 --minify",
@@ -33,6 +30,9 @@
 		"type-check": "tsc",
 		"prepack": "pnpm build && ./dist/index.mjs",
 		"prepare": "skills-npm"
+	},
+	"engines": {
+		"node": ">=22"
 	},
 	"devDependencies": {
 		"@types/node": "^22.19.15",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,12 @@
 	],
 	"type": "module",
 	"bin": "dist/index.mjs",
+	"engines": {
+		"node": ">=22"
+	},
 	"packageManager": "pnpm@9.15.4",
 	"scripts": {
-		"build": "pkgroll --target=node12.19 --minify",
+		"build": "pkgroll --target=node22 --minify",
 		"lint": "lintroll --cache .",
 		"test": "node tests/index.ts",
 		"type-check": "tsc",


### PR DESCRIPTION
## Problem

Node.js 20 reached end-of-life on 2026-04-30, making **Node 22** the lowest maintained LTS. The build still targets `node12.19`, and the absence of an `engines` field means npm advertises support for long-EOL runtimes. Holding that floor also blocks using modern, faster APIs (e.g. `fs.readdir({ recursive: true })`, Node 20.1+).

## Changes

- Add `"engines": { "node": ">=22" }`.
- Bump the build target: `pkgroll --target=node12.19` → `--target=node22`.

`.nvmrc` (dev/CI) stays at 24.14.0, which is above the new floor.

## Notes

- This is intentionally a **standalone breaking change**, separate from the exports/imports pruning work in #22. #22 will rebase onto this so it can use modern fs APIs.
- Verified: `pkgroll --target=node22` builds cleanly, the built bin runs, and the existing test suite passes.

BREAKING CHANGE: clean-pkg-json now requires Node.js >=22.
